### PR TITLE
Extended polynomial expressions

### DIFF
--- a/+casos/@PS/PS.m
+++ b/+casos/@PS/PS.m
@@ -123,7 +123,7 @@ methods
 
     function tf = is_symexpr(obj)
         % Check if polynomial contains symbolic expressions.
-        tf = ~isconstant(obj.coeffs);
+        tf = ~is_constant(obj.coeffs);
     end
 
     function tf = is_zerodegree(obj)

--- a/+casos/@PS/PS.m
+++ b/+casos/@PS/PS.m
@@ -73,7 +73,7 @@ methods
 
     function n = get.nterm(obj)
         % Number of monomials.
-        n = size(obj.coeffs,1);
+        n = size(obj.degmat,1);
     end
 
     function d = get.mindeg(obj)
@@ -233,6 +233,11 @@ methods (Access=protected)
     obj = parenDelete(obj,idx);
     n = parenListLength(obj,idx,context);
     varargout = parenReference(obj,index);
+
+    % protected interface for subsref getters
+    [monoms,L] = get_monoms(p,I);
+    [degree,L] = get_degree(p,I);
+    [indets,L] = get_indets(p,I);
 end
 
 end

--- a/+casos/@PS/PS.m
+++ b/+casos/@PS/PS.m
@@ -130,6 +130,11 @@ methods
         tf = ~is_constant(obj.coeffs);
     end
 
+    function tf = is_symgram(obj)
+        % Check if polynomial is in symbolic Gram form.
+        tf = ~isempty(grammatrix(obj));
+    end
+
     function tf = is_zerodegree(obj)
         % Check if polynomial is of degree zero.
         tf = (obj.maxdeg == 0);

--- a/+casos/@PS/PS.m
+++ b/+casos/@PS/PS.m
@@ -131,6 +131,11 @@ methods
         tf = (obj.maxdeg == 0);
     end
 
+    function tf = is_zero(obj)
+        % Check if polynomial is equal to zero.
+        tf = (is_zerodegree(obj) && is_zero(obj.coeffs));
+    end
+
     function tf = is_constant(obj)
         % Check if polynomial is constant.
         tf = (is_zerodegree(obj) && ~is_symexpr(obj));

--- a/+casos/@PS/PS.m
+++ b/+casos/@PS/PS.m
@@ -41,17 +41,21 @@ methods
                 % syntax PS('x')
                 n = 1; m = 1;
                 obj.indets = {var};
+                iv = 1;
             elseif ischar([arg{:}])
                 % syntax PS('x','y',...)
                 n = length(varargin); m = 1;
-                obj.indets = varargin;
+                % sort variables alphabetically
+                [obj.indets,iv] = unique(varargin);
             else
                 % syntax PS('x',m,n)
                 [n,m] = size(zeros(arg{:}));
                 obj.indets = compose('%s_%d',var,1:(n*m));
+                iv = 1:(n*m);
             end
 
-            obj.coeffs = casadi.SX.eye(n*m);
+            % return variables in requested order
+            obj.coeffs = casadi.SX.triplet(iv-1,0:(n*m-1),ones(1,n*m),n*m,n*m);
             obj.degmat = speye(n*m);
             obj.matdim = [n m];
 

--- a/+casos/@PS/blkdiag.m
+++ b/+casos/@PS/blkdiag.m
@@ -17,7 +17,7 @@ case 2
     b = casos.PS(varargin{2});
 
     % size of block diagional
-    sz = siza(a) + size(b);
+    sz = size(a) + size(b);
 
     % combine variables
     [indets,dga,dgb] = combineVar(a.indets,b.indets,a.degmat,b.degmat);

--- a/+casos/@PS/cat.m
+++ b/+casos/@PS/cat.m
@@ -76,7 +76,7 @@ function [cf,dg] = extendDC(i,q,dim,sizes,sz,nvi,ic)
     [ii,ji,di] = find(q.degmat);
 
     % extend degree matrix
-    dg = sparse(ii,ic(sum([nvi{1:i-1}])+ji),di,q.nterm,max(ic));
+    dg = sparse(ii,ic(sum([nvi{1:i-1}])+ji),di,q.nterm,max([0 ic]));
 
     % extend coefficient matrix
     % let a1,...,aL, b1,...,bM, c1,...,cN be the columns of A, B, C

--- a/+casos/@PS/disp.m
+++ b/+casos/@PS/disp.m
@@ -1,5 +1,5 @@
 function disp(obj)
-% Display polynomial.
+% Print polynomial to command line (display).
 
 % Mostly taken from multipoly, version history:
 % 6/7/2002: PJS  Initial Coding

--- a/+casos/@PS/get_degree.m
+++ b/+casos/@PS/get_degree.m
@@ -30,7 +30,7 @@ L = logical(Ldegmat*(degsum == degrees));
 
 if nargin > 1
     % find degrees that appear in subsref
-    degrees = degrees(any(L(I,:)));
+    degrees = degrees(any(L(I,:),1));
 end
 
 end

--- a/+casos/@PS/get_degree.m
+++ b/+casos/@PS/get_degree.m
@@ -26,7 +26,7 @@ degrees = full(unique(degsum'));
 [~,Ldegmat] = get_degmat(p);
 
 % map degrees to entries
-L = Ldegmat*(degsum == degrees);
+L = logical(Ldegmat*(degsum == degrees));
 
 if nargin > 1
     % find degrees that appear in subsref

--- a/+casos/@PS/get_degree.m
+++ b/+casos/@PS/get_degree.m
@@ -1,0 +1,36 @@
+function [degrees,L] = get_degree(p,I)
+% Return vector of degrees of polynomial terms.
+%
+% Available syntax:
+%
+%   degrees = get_degree(p)
+%
+% Returns ordered vector of degrees in polynomial `p`.
+%
+%   [...,L] = get_degree(p)
+%
+% If p is an n-by-m vector of polynomials with l monomial terms, this 
+% returns an (n*m)-by-l logical matrix of component L_ij, indicating 
+% whether the entry `p(i)` has term of degree `degrees(j)`.
+%
+%   degrees = get_degree(p,I)
+%
+% Returns ordered vector of degrees in the polynomial expression `p(I)`.
+
+degsum = sum(p.degmat,2);
+
+% vector of degrees
+degrees = full(unique(degsum'));
+
+% get logical map of degrees
+[~,Ldegmat] = get_degmat(p);
+
+% map degrees to entries
+L = Ldegmat*(degsum == degrees);
+
+if nargin > 1
+    % find degrees that appear in subsref
+    degrees = degrees(any(L(I,:)));
+end
+
+end

--- a/+casos/@PS/get_indets.m
+++ b/+casos/@PS/get_indets.m
@@ -27,7 +27,7 @@ L = logical(Ldegmat*(degmat > 0));
 
 if nargin > 1
     % find variables that appear in subsref
-    indets = indets(any(L(I,:)));
+    indets = indets(any(L(I,:),1));
 end
 
 x = casos.PS(indets{:});

--- a/+casos/@PS/get_indets.m
+++ b/+casos/@PS/get_indets.m
@@ -23,7 +23,7 @@ indets = p.indets;
 [degmat,Ldegmat] = get_degmat(p);
 
 % map variable appearance to entries
-L = Ldegmat*(degmat > 0);
+L = logical(Ldegmat*(degmat > 0));
 
 if nargin > 1
     % find variables that appear in subsref

--- a/+casos/@PS/get_indets.m
+++ b/+casos/@PS/get_indets.m
@@ -1,0 +1,35 @@
+function [x,L] = get_indets(p,I)
+% Return indeterminate variables of polynomial.
+%
+% Available syntax:
+%
+%   x = get_indets(p)
+%
+% Returns indeterminate variables of polynomial `p`.
+%
+%   [...,L] = get_indets(p)
+%
+% If p is an n-by-m vector of polynomials with l monomial terms, this 
+% returns an (n*m)-by-l logical matrix of component L_ij, indicating 
+% whether the entry `p(i)` has the indeterminate variable x(j)`.
+%
+%   x = get_indets(p,I)
+%
+% Returns indeterminate variables of the polynomial expression `p(I)`.
+
+indets = p.indets;
+
+% get logical map of degrees
+[degmat,Ldegmat] = get_degmat(p);
+
+% map variable appearance to entries
+L = Ldegmat*(degmat > 0);
+
+if nargin > 1
+    % find variables that appear in subsref
+    indets = indets(any(L(I,:)));
+end
+
+x = casos.PS(indets{:});
+
+end

--- a/+casos/@PS/get_monoms.m
+++ b/+casos/@PS/get_monoms.m
@@ -1,0 +1,31 @@
+function [z,L] = get_monoms(p,varargin)
+% Return vector of monomials of polynomial.
+%
+% Available syntax:
+%
+%   monoms = get_monoms(p)
+%
+% Returns (unsorted) vector of monomials in polynomial `p`.
+%
+%   [...,L] = get_monoms(p)
+%
+% If p is an n-by-m vector of polynomials with l monomial terms, this 
+% returns an (n*m)-by-l logical matrix of component L_ij, indicating 
+% whether the entry `p(i)` has monomials `monoms(j)`.
+%
+%   monoms = get_monoms(p,I)
+%
+% Returns vector of monomials in the polynomial expression `p(I)`.
+
+indets = p.indets;
+
+% get degrees in subsref
+[degmat,L] = get_degmat(p,varargin{:});
+
+% select variables in subsref
+Ivar = any(degmat > 0);
+
+% TODO: sort?
+z = build_monomials(degmat(:,Ivar),indets(Ivar));
+
+end

--- a/+casos/@PS/get_monoms.m
+++ b/+casos/@PS/get_monoms.m
@@ -23,7 +23,7 @@ indets = p.indets;
 [degmat,L] = get_degmat(p,varargin{:});
 
 % select variables in subsref
-Ivar = any(degmat > 0);
+Ivar = any(degmat > 0,1);
 
 % monomials are already sorted canonically
 z = build_monomials(degmat(:,Ivar),indets(Ivar));

--- a/+casos/@PS/get_monoms.m
+++ b/+casos/@PS/get_monoms.m
@@ -25,7 +25,7 @@ indets = p.indets;
 % select variables in subsref
 Ivar = any(degmat > 0);
 
-% TODO: sort?
+% monomials are already sorted canonically
 z = build_monomials(degmat(:,Ivar),indets(Ivar));
 
 end

--- a/+casos/@PS/grambasis.m
+++ b/+casos/@PS/grambasis.m
@@ -1,0 +1,95 @@
+function [Z,K,z] = grambasis(p)
+% Return Gram basis of polynomial vector.
+
+lp = numel(p);
+
+% get logical maps for degrees and indeterminate variables
+% -> Ldeg(i,j) is true iff p(i) has terms of degree(j)
+% -> Lvar(i,j) is true iff p(i) has terms in indets(j)
+[degree,Ldeg] = get_degree(p);
+[indets,Lvar] = get_indets(p);
+
+% min and max degree of Gram basis vector
+mndg = floor(min(degree)/2);
+mxdg =  ceil(max(degree)/2);
+
+% ensure min and max degree are even
+[degree,ii] = unique([degree,(2*mndg):(2*mxdg)]);
+ld = length(degree); tmp = [Ldeg false(lp,ld)];
+Ldeg = tmp(:,ii);
+
+% split into even and odd monomials
+Ldeg_e = Ldeg(:,mod(degree,2)==0);
+Ldeg_o = Ldeg(:,mod(degree,2) >0);
+% add even degrees if necessary
+Ldeg_e(:,1:end-1) = Ldeg_e(:,1:end-1) | Ldeg_o;
+Ldeg_e(:,2:end) = Ldeg_e(:,2:end) | Ldeg_o;
+
+% get half-degree vector of monomials
+% TODO: compute degree matrix directly (avoid unnecessary checks)
+z = monomials(indets,mndg:mxdg);
+% compute logical map for half-degree monomials
+% -> Lz_deg(i,j) is true iff z(i) is of degree(j)/2
+% -> Lz_var(i,j) is true iff z(i) includes indets(j)
+[~,Lz_deg] = get_degree(z);
+[~,Lz_var] = get_indets(z);
+
+% build logical map for half-degree monomials
+% -> Lz(i,j) is true iff Gram form of p(i) includes z(j)
+% that is, z(j) is of a degree in the Gram basis for p(i)
+% AND z(j) only has indeterminate variables that p(i) has, too
+Lz = (Ldeg_e * Lz_deg' & ~(~Lvar * Lz_var'));
+
+% discard monomials based on simple checks
+% TODO: perform checks vector-wise
+Imx = any(  ceil(max(p.degmat,[],1)/2) < z.degmat , 2 );
+Imn = any( floor(min(p.degmat,[],1)/2) > z.degmat , 2 );
+Lz(:,Imx | Imn) = false;
+
+% remove unused monomials from base vector
+I = any(Lz,1);
+Lz(:,~I) = [];
+degmat = z.degmat(I,:);
+z = build_monomials(degmat,z.indets);
+
+% dimension K(i) of Gram basis for p(i)
+K = full(sum(Lz,2));
+
+% build square matrix of monomials
+nt = size(degmat,1);
+% vectorized square matrix S = z*z^T
+D = kron(degmat,ones(nt,1)) + kron(ones(nt,1),degmat);
+% build logical map for square matrix
+% -> L(i,j) is true iff square matrix for p(i) includes S(j)
+% that is, S(j) = z(j1)*z(j2) 
+% and Gram form of p(i) includes z(j1) and z(j2)
+L = kron(Lz,ones(1,nt)) & kron(ones(1,nt),Lz);
+
+% remove unused monomials from square matrix
+I = any(L,1);
+L(:,~I) = [];
+D(~I,:) = [];
+
+% build coefficients for output
+%
+%       [ S(i1) ... S(iN) |   0   ...   0   |   0   ...   0   | ... ]
+% Z^T = [   0   ...   0   | S(j1) ... S(jM) |   0   ...   0   | ... ]
+%       [   0   ...   0   |   0   ...   0   | S(k1) ... S(kL) | ... ]
+%
+% where i_, j_, k_ are those indices satisfying that
+% L(1,i_), L(2,j_), L(3,k_), respectively, are true
+lZ = sum(K.^2);
+nT = size(D,1);
+
+% enumerate entries of S, first for p(1), then p(2), ...
+% index into entries -> set {(i,j) : p(j) includes S(i)}
+[i,j] = find(L');
+
+% coefficient matrix for Z
+coeffs = casadi.SX.triplet(i-1, (j-1)'.*lZ+(1:lZ)-1, ones(lZ,1), nT, lp*lZ);
+
+% set output
+Z = casos.PS;
+[Z.coeffs,Z.degmat] = uniqueDeg(coeffs,D);
+Z.indets = p.indets;
+Z.matdim = [lZ lp];

--- a/+casos/@PS/grambasis.m
+++ b/+casos/@PS/grambasis.m
@@ -41,10 +41,17 @@ z = monomials(indets,mndg:mxdg);
 Lz = (Ldeg_e * Lz_deg' & ~(~Lvar * Lz_var'));
 
 % discard monomials based on simple checks
-% TODO: perform checks vector-wise
-Imx = any(  ceil(max(p.degmat,[],1)/2) < z.degmat , 2 );
-Imn = any( floor(min(p.degmat,[],1)/2) > z.degmat , 2 );
-Lz(:,Imx | Imn) = false;
+[~,Ldegmat] = get_degmat(p);
+lz = numel(z);
+% perform checks vector-wise
+MX = arrayfun(@(i) repmat(max(p.degmat(Ldegmat(i,:),:),[],1),lz,1), 1:lp, 'UniformOutput', false);
+MN = arrayfun(@(i) repmat(min(p.degmat(Ldegmat(i,:),:),[],1),lz,1), 1:lp, 'UniformOutput', false);
+% Imx = any(  ceil(max(p.degmat,[],1)/2) < z.degmat , 2 );
+% Imn = any( floor(min(p.degmat,[],1)/2) > z.degmat , 2 );
+zdm = repmat(z.degmat,lp,1);
+Irem = [ceil(vertcat(MX{:})/2) < zdm, floor(vertcat(MN{:})/2) > zdm];
+% Lz(:,Imx | Imn) = false;
+Lz(reshape(any(Irem,2),lz,lp)') = false;
 
 % remove unused monomials from base vector
 I = any(Lz,1);

--- a/+casos/@PS/grambasis.m
+++ b/+casos/@PS/grambasis.m
@@ -1,13 +1,26 @@
-function [Z,K,z] = grambasis(p)
+function [Z,K,z] = grambasis(p,I)
 % Return Gram basis of polynomial vector.
 
-lp = numel(p);
+if nargin < 2
+    lp = numel(p);
+    I = true(lp,1);
+    idx = 1:lp;
+else
+    lp = nnz(I);
+    idx = find(I);
+end
 
 % get logical maps for degrees and indeterminate variables
 % -> Ldeg(i,j) is true iff p(i) has terms of degree(j)
 % -> Lvar(i,j) is true iff p(i) has terms in indets(j)
-[degree,Ldeg] = get_degree(p);
-[indets,Lvar] = get_indets(p);
+[degree,Ldeg] = get_degree(p,I);
+[indets,Lvar] = get_indets(p,I);
+% remove non-indexed logicals
+Ldeg(~I,:) = []; Lvar(~I,:) = [];
+% detect degrees and variables
+Id = any(Ldeg,1); Iv = any(Lvar,1);
+% remove unused degrees or variables
+Ldeg(:,~Id) = []; Lvar(:,~Iv) = [];
 
 % min and max degree of Gram basis vector
 mndg = floor(min(degree)/2);
@@ -44,8 +57,8 @@ Lz = (Ldeg_e * Lz_deg' & ~(~Lvar * Lz_var'));
 [~,Ldegmat] = get_degmat(p);
 lz = numel(z);
 % perform checks vector-wise
-MX = arrayfun(@(i) repmat(max(p.degmat(Ldegmat(i,:),:),[],1),lz,1), 1:lp, 'UniformOutput', false);
-MN = arrayfun(@(i) repmat(min(p.degmat(Ldegmat(i,:),:),[],1),lz,1), 1:lp, 'UniformOutput', false);
+MX = arrayfun(@(i) repmat(max(p.degmat(Ldegmat(i,:),Iv),[],1),lz,1), idx, 'UniformOutput', false);
+MN = arrayfun(@(i) repmat(min(p.degmat(Ldegmat(i,:),Iv),[],1),lz,1), idx, 'UniformOutput', false);
 % Imx = any(  ceil(max(p.degmat,[],1)/2) < z.degmat , 2 );
 % Imn = any( floor(min(p.degmat,[],1)/2) > z.degmat , 2 );
 zdm = repmat(z.degmat,lp,1);

--- a/+casos/@PS/grammatrix.m
+++ b/+casos/@PS/grammatrix.m
@@ -1,23 +1,29 @@
-function [Q,Z,K,z] = grammatrix(p)
+function [Q,Z,K,z] = grammatrix(p,I)
 % Attempts to compute a symbolic Gram matrix for polynomial vector.
 
+if nargin < 2
+    I = true(size(p));
+end
+
 % compute Gram basis vector
-[Z,K,z] = grambasis(p);
+[Z,K,z] = grambasis(p,I);
 
 % get symbolic variables from coefficients
-syms = symvar(p.coeffs);
+syms = symvar(p.coeffs(:,find(I)));
 
-% check dimensions if are compatible
+% check if dimensions are compatible
 if length(syms) == sum(K.^2)
 
 % stack symbols horizontally
 Q = horzcat(syms{:});
 
 % attempt to build Gram form
-pgram = (Q*Z)';
+pgram = casos.PS.zeros(size(p));
+pgram(I) = (Q*Z)';
 
 % check if Gram form is equal
-if isequal(p, pgram)
+diff = (p - pgram);
+if is_zero(diff.coeffs(:,find(I)))
     % return Gram matrix
     return
 end

--- a/+casos/@PS/grammatrix.m
+++ b/+casos/@PS/grammatrix.m
@@ -1,0 +1,31 @@
+function [Q,Z,K,z] = grammatrix(p)
+% Attempts to compute a symbolic Gram matrix for polynomial vector.
+
+% compute Gram basis vector
+[Z,K,z] = grambasis(p);
+
+% get symbolic variables from coefficients
+syms = symvar(p.coeffs);
+
+% check dimensions if are compatible
+if length(syms) == sum(K.^2)
+
+% stack symbols horizontally
+Q = horzcat(syms{:});
+
+% attempt to build Gram form
+pgram = (Q*Z)';
+
+% check if Gram form is equal
+if isequal(p, pgram)
+    % return Gram matrix
+    return
+end
+
+end
+
+% else:
+% return empty Gram matrix
+Q = [];
+
+end

--- a/+casos/@PS/isequal.m
+++ b/+casos/@PS/isequal.m
@@ -1,0 +1,12 @@
+function tf = isequal(a,b)
+% Check if polynomial arrays are equal.
+
+if ~isequal(size(a),size(b))
+    tf = false;
+    return
+end
+
+% else
+tf = is_zero(a-b);
+
+end

--- a/+casos/@PS/kron.m
+++ b/+casos/@PS/kron.m
@@ -1,5 +1,5 @@
 function c = kron(a,b)
-% Kronecker product of two polynomial matrices.
+% Compute Kronecker product of two polynomial matrices.
 
 a = casos.PS(a);
 b = casos.PS(b);

--- a/+casos/@PS/kron.m
+++ b/+casos/@PS/kron.m
@@ -52,10 +52,7 @@ degmat = dga(Ia(:),:) + dgb(Ib(:),:);
 coeffs = cfa(Ia(:),ja(:)).*cfb(Ib(:),jb(:));
 
 % make degree matrix unique
-[degmat,id,ic] = unique(degmat,'rows','sorted');
-% sum repeated coefficients
-summat = sparse(ic,1:(nta*ntb),1,length(id),nta*ntb);
-coeffs = summat*coeffs;
+[coeffs,degmat] = uniqueDeg(coeffs,degmat);
 
 % new polynomial
 c.coeffs = coeffs;

--- a/+casos/@PS/monomials.m
+++ b/+casos/@PS/monomials.m
@@ -40,15 +40,8 @@ else
     degmat = M(I,:);
 end
 
-% number of monomials
-nt = size(degmat,1);
-
 % set output
-Z = casos.PS;
-Z.coeffs = casadi.SX.eye(nt);
-Z.degmat = sparse(degmat);
-Z.indets = indets;
-Z.matdim = [nt 1];
+Z = build_monomials(degmat,indets);
 
 end
 

--- a/+casos/@PS/monomials.m
+++ b/+casos/@PS/monomials.m
@@ -52,15 +52,16 @@ Z.matdim = [nt 1];
 
 end
 
-function [M,l] = degreemat(M, l, m, d)
+function [M,l] = degreemat(M, l0, m, d)
 % Build degree matrix for m variables and degree d.
 
     switch m
-        case 1, M(l,end) = d; l = l+1;
+        case 1, M(l0,end) = d; l = l0+1;
         otherwise
             for j = 0:d
-                M(l,end-m+1) = d - j;
-                [M,l] = degreemat(M,l,m-1,j);
+                [M,l] = degreemat(M,l0,m-1,j);
+                M(l0:l-1,end-m+1) = d - j;
+                l0 = l;
             end
     end
 end

--- a/+casos/@PS/monomials.m
+++ b/+casos/@PS/monomials.m
@@ -8,12 +8,8 @@ indets = p.indets;
 if nargin == 1
     % Return vector of monomials in polynomial.
 
-    % TODO: can we assume that degrees are already sorted?
-    % from multipoly:
-    % Flipping/sorting to return output in lexicographic order
-    % (sorted by degree then by alphabetical order)
-    degmatsort = sortrows([sum(p.degmat,2) fliplr(p.degmat)]);
-    degmat = fliplr(degmatsort(:,2:end));
+    % degrees are in graded reverse lexicographic order (canonic)
+    degmat = p.degmat;
 
 elseif deg == 0
     % Return constant one.
@@ -28,9 +24,9 @@ else
     % enumerate monomials up to max(deg)
     r = nchoosek(p.nvars+max(deg),p.nvars); % total number of monomials
     M = nan(r,p.nvars);
-    % iterate over degrees
+    % iterate over ascending degrees
     l = 1;
-    for i = deg
+    for i = unique(deg)
         [M,l] = degreemat(M,l,p.nvars,i);
     end
 
@@ -47,13 +43,14 @@ end
 
 function [M,l] = degreemat(M, l0, m, d)
 % Build degree matrix for m variables and degree d.
+% Monomials will be in graded REVERSE lexicographic order.
 
     switch m
-        case 1, M(l0,end) = d; l = l0+1;
+        case 1, M(l0,1) = d; l = l0+1;
         otherwise
-            for j = 0:d
+            for j = d:-1:0
                 [M,l] = degreemat(M,l0,m-1,j);
-                M(l0:l-1,end-m+1) = d - j;
+                M(l0:l-1,m) = d - j;
                 l0 = l;
             end
     end

--- a/+casos/@PS/mtimes.m
+++ b/+casos/@PS/mtimes.m
@@ -18,7 +18,7 @@ szb = size(b);
 errsz = 'Polynomials have incompatible sizes for this operation ([%s] vs. [%s]).';
 
 % dimensions are compatible if inner dimensions agree
-assert(sza(2) == szb(1), errsz, sza, szb)
+assert(sza(2) == szb(1), errsz, size2str(sza), size2str(szb))
 
 % TODO: handle or escape for other simple cases, e.g., scalar, constant
 % matrix, single term etc.?

--- a/+casos/@PS/parenAssign.m
+++ b/+casos/@PS/parenAssign.m
@@ -20,8 +20,13 @@ assert(length(varargin) == 1, 'Too many arguments on right-hand side.')
 % assignment
 q = casos.PS(varargin{:});
 
+% input terms and dimensions
 nta = obj.nterm;
 ntb = q.nterm;
+szq = size(q);
+
+% prepare error message for incompatible sizes
+errsz = 'Incompatible sizes for assignment (left: [%s] vs. right: [%s].';
 
 % combine variables
 [indets,dga,dgb] = combineVar(obj.indets,q.indets,obj.degmat,q.degmat);
@@ -32,6 +37,9 @@ I.(idx) = 1;
 
 % size of reference
 sz = size(I.(idx));
+
+% dimensions are compatible if equal or right side is row/column
+assert(all(sz == szq | szq == 1), errsz, size2str(sz), size2str(szq));
 
 % reshape to referenced size
 cfb = reshape(repmat(q.coeffs,sz./size(q)),ntb,prod(sz));

--- a/+casos/@PS/parenReference.m
+++ b/+casos/@PS/parenReference.m
@@ -10,11 +10,13 @@ I.(idx) = 1;
 
 if length(indexOp) > 1 && indexOp(2).Type == "Dot"
     % handle getters on referenced polynomial
+    done = true;
+
     switch (indexOp(2).Name)
         case 'mindeg'
-            res = min(get_degree(obj,find(I)));
+            res = min(get_degree(obj,find(I)))';
         case 'maxdeg'
-            res = max(get_degree(obj,find(I)));
+            res = max(get_degree(obj,find(I)))';
         case 'nvars'
             res = length(get_indets(obj,find(I)));
         case 'nterm'
@@ -25,10 +27,10 @@ if length(indexOp) > 1 && indexOp(2).Type == "Dot"
             res = get_monoms(obj,find(I));
         otherwise
             % getter not supported
-            res = [];
+            done = false;
     end
 
-    if isempty(res)
+    if ~done
         % continue
     elseif length(indexOp) > 2
         [varargout{1:nargout}] = res.(indexOp(3:end));
@@ -39,17 +41,19 @@ if length(indexOp) > 1 && indexOp(2).Type == "Dot"
     end
 end
 
-% reference coefficients
-coeffs = obj.coeffs(:,find(I));
-
 % new polynomial
 p = casos.PS;
-% remove coefficients, degrees, and/or indeterminates 
-% that do not appear in the referenced polynomial
-[p.coeffs,p.degmat,p.indets] = removeZero(coeffs,obj.degmat,obj.indets);
-% resize
-p.matdim = size(I.(idx));
 
+if nnz(I) > 0
+    % reference coefficients
+    coeffs = obj.coeffs(:,find(I));
+    
+    % remove coefficients, degrees, and/or indeterminates 
+    % that do not appear in the referenced polynomial
+    [p.coeffs,p.degmat,p.indets] = removeZero(coeffs,obj.degmat,obj.indets);
+    % resize
+    p.matdim = size(I.(idx));
+end
 
 if length(indexOp) > 1
     % forward reference

--- a/+casos/@PS/parenReference.m
+++ b/+casos/@PS/parenReference.m
@@ -5,8 +5,8 @@ function varargout = parenReference(obj,indexOp)
 idx = indexOp(1);
 
 % select referenced elements
-I = sparse(size(obj,1),size(obj,2));
-I.(idx) = 1;
+I = logical(sparse(size(obj,1),size(obj,2)));
+I.(idx) = true;
 
 if length(indexOp) > 1 && indexOp(2).Type == "Dot"
     % handle getters on referenced polynomial
@@ -14,17 +14,17 @@ if length(indexOp) > 1 && indexOp(2).Type == "Dot"
 
     switch (indexOp(2).Name)
         case 'mindeg'
-            res = min(get_degree(obj,find(I)))';
+            res = min(get_degree(obj,I))';
         case 'maxdeg'
-            res = max(get_degree(obj,find(I)))';
+            res = max(get_degree(obj,I))';
         case 'nvars'
-            res = length(get_indets(obj,find(I)));
+            res = length(get_indets(obj,I));
         case 'nterm'
-            res = size(get_degmat(obj,find(I)),1);
+            res = size(get_degmat(obj,I),1);
         case 'indeterminates'
-            res = get_indets(obj,find(I));
+            res = get_indets(obj,I);
         case 'monomials'
-            res = get_monoms(obj,find(I));
+            res = get_monoms(obj,I);
         otherwise
             % getter not supported
             done = false;

--- a/+casos/@PS/parenReference.m
+++ b/+casos/@PS/parenReference.m
@@ -8,6 +8,37 @@ idx = indexOp(1);
 I = sparse(size(obj,1),size(obj,2));
 I.(idx) = 1;
 
+if length(indexOp) > 1 && indexOp(2).Type == "Dot"
+    % handle getters on referenced polynomial
+    switch (indexOp(2).Name)
+        case 'mindeg'
+            res = min(get_degree(obj,find(I)));
+        case 'maxdeg'
+            res = max(get_degree(obj,find(I)));
+        case 'nvars'
+            res = length(get_indets(obj,find(I)));
+        case 'nterm'
+            res = size(get_degmat(obj,find(I)),1);
+        case 'indeterminates'
+            res = get_indets(obj,find(I));
+        case 'monomials'
+            res = get_monoms(obj,find(I));
+        otherwise
+            % getter not supported
+            res = [];
+    end
+
+    if isempty(res)
+        % continue
+    elseif length(indexOp) > 2
+        [varargout{1:nargout}] = res.(indexOp(3:end));
+        return
+    else
+        varargout = {res};
+        return
+    end
+end
+
 % reference coefficients
 coeffs = obj.coeffs(:,find(I));
 

--- a/+casos/@PS/plus.m
+++ b/+casos/@PS/plus.m
@@ -19,7 +19,7 @@ I0 = (sza == 0) | (szb == 0);
 I1 = (sza == 1) | (szb == 1);
 
 % dimensions are compatible if equal or one summand is row/column
-assert(all(I | I1), errsz, sza, szb)
+assert(all(I | I1), errsz, size2str(sza), size2str(szb))
 
 % dimensions of sum
 sz = max(sza,szb);

--- a/+casos/@PS/power.m
+++ b/+casos/@PS/power.m
@@ -18,7 +18,7 @@ I0 = (sza == 0) | (szn == 0);
 I1 = (sza == 1) | (szn == 1);
 
 % dimensions are compatible if equal or one factor is row/column
-assert(all(I | I1), errsz, sza, szn)
+assert(all(I | I1), errsz, size2str(sza), size2str(szn))
 
 % dimensions of element-wise product
 sz = max(sza,szn);

--- a/+casos/@PS/private/build_monomials.m
+++ b/+casos/@PS/private/build_monomials.m
@@ -1,0 +1,15 @@
+function z = build_monomials(degmat,indets)
+% Build a monomial vector.
+
+z = casos.PS;
+
+% number of monomials
+nt = size(degmat,1);
+
+% set output
+z.coeffs = casadi.SX.eye(nt);
+z.degmat = sparse(degmat);
+z.indets = indets;
+z.matdim = [nt 1];
+
+end

--- a/+casos/@PS/private/get_degmat.m
+++ b/+casos/@PS/private/get_degmat.m
@@ -1,0 +1,33 @@
+function [degmat,L] = get_degmat(p,I)
+% Return degree matrix of polynomial.
+%
+% Available syntax:
+%
+%   degmat = get_degmat(p)
+%
+% Returns degree matrix in polynomial `p`.
+%
+%   [...,L] = get_degmat(p)
+%
+% If p is an n-by-m vector of polynomials with l monomial terms, this 
+% returns an (n*m)-by-l logical matrix of component L_ij, indicating 
+% whether the degree matrix of `p(i)` has a row `degmat(j,:)`.
+%
+%   degmat = get_degmat(p,I)
+%
+% Returns degree matrix in the polynomial expression `p(I)`.
+
+degmat = p.degmat;
+
+% sparsity of coefficients
+S = sparsity(p.coeffs);
+% convert CasADi sparsity into logical matrix
+[i,j] = ind2sub(size(S),find(S));
+L = sparse(j,i,true,size2(S),size1(S));
+
+if nargin > 1
+    % find degrees that appear in subsref
+    degmat = degmat(any(L(I,:),1),:);
+end
+
+end

--- a/+casos/@PS/private/size2str.m
+++ b/+casos/@PS/private/size2str.m
@@ -1,0 +1,6 @@
+function str = size2str(sz)
+% Convert array size into string.
+
+    str = sprintf('%dx%d', sz(1), sz(2));
+end
+

--- a/+casos/@PS/private/uniqueDeg.m
+++ b/+casos/@PS/private/uniqueDeg.m
@@ -1,23 +1,19 @@
-function [coeffs,degmat] = uniqueDeg(coeffs,degmat,setOrder)
+function [coeffs,degmat] = uniqueDeg(coeffs,degmat)
 % Make degree matrix unique and return corresponding coefficients.
-
-if nargin < 3
-    setOrder = 'sorted';
-end
+%
+% This function ensures that the monomials are in graded REVERSE
+% lexicographic order.
 
 nt = size(coeffs,1);
 
 % make degree matrix unique
-[degmat,id,ic] = unique(degmat,'rows',setOrder);
+[degmat2,id,ic] = unique(fliplr(degmat),'rows','sorted');
 
 % sum repeated coefficients
 summat = sparse(ic,1:nt,1,length(id),nt);
 coeffs = sparsify(summat*coeffs);
 
-% reverse order of degrees if sorted by unique
-if isequal(setOrder,'sorted')
-    coeffs = flipud(coeffs);
-    degmat = flipud(degmat);
-end
+% reverse order of degrees
+degmat = fliplr(degmat2);
 
 end

--- a/+casos/@PS/sym.m
+++ b/+casos/@PS/sym.m
@@ -8,12 +8,16 @@ end
 if nargin < 3
     % default size: scalar
     sz = [1 1];
-elseif isscalar(sz)
-    sz = [sz sz];
-elseif ~isrow(sz) || ~numel(sz) == 2
-    error('Third input must be scalar or 1x2 vector of dimensions.')
+elseif ischar(sz)
+    type = sz;
+    % default size: scalar
+    sz = [1 1];
 end
 if nargin < 2
+    % default monomials: 1
+    w = casos.PS(1);
+elseif isnumeric(w) && nargin < 3
+    sz = w;
     % default monomials: 1
     w = casos.PS(1);
 else
@@ -22,6 +26,11 @@ else
 end
 if nargin < 1
     error('Undefined inputs.');
+end
+if isscalar(sz)
+    sz = [sz sz];
+elseif ~isrow(sz) || ~numel(sz) == 2
+    error('Third input must be scalar or 1x2 vector of dimensions.')
 end
 
 p = casos.PS;

--- a/+casos/@PS/sym.m
+++ b/+casos/@PS/sym.m
@@ -37,12 +37,13 @@ switch type
         Q = casadi.SX.sym(dstr,nt^2,ne);  % Gram matrices, TODO: symmetric?
         D = kron(w.degmat,ones(nt,1)) + kron(ones(nt,1),w.degmat);
         % make degree matrix unique
-        [p.coeffs,p.degmat] = uniqueDeg(Q,D,'stable');
+        [p.coeffs,p.degmat] = uniqueDeg(Q,D);
 
     otherwise
         % create using coefficient vector form
         p.coeffs = casadi.SX.sym(dstr,nt,ne);
-        p.degmat = w.degmat; % TODO: match ordering in w
+        % degree matrix is already sorted canonically
+        p.degmat = w.degmat;
 end
 
 % set indeterminates + dimensions

--- a/+casos/@PS/times.m
+++ b/+casos/@PS/times.m
@@ -19,7 +19,7 @@ I0 = (sza == 0) | (szb == 0);
 I1 = (sza == 1) | (szb == 1);
 
 % dimensions are compatible if equal or one factor is row/column
-assert(all(I | I1), errsz, sza, szb)
+assert(all(I | I1), errsz, size2str(sza), size2str(szb))
 
 % dimensions of element-wise product
 sz = max(sza,szb);

--- a/+casos/@PS/to_multipoly.m
+++ b/+casos/@PS/to_multipoly.m
@@ -1,0 +1,11 @@
+function q = to_multipoly(p)
+% Convert a polynomial with constant coefficients into a multipoly object.
+
+assert(~is_symexpr(p), 'Cannot convert polynomials with symbolic coefficients.')
+
+% get coefficients
+coeffs = casadi.DM(p.coeffs);
+
+q = polynomial(sparse(coeffs),p.degmat,p.indets,p.matdim);
+
+end

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ casos.PS(m,n)
 casos.PS.zeros(m,n)
 casos.PS.zeros(n)
 ```
-creates a zero-degree polynomial which corresponds to a `m × n` matrix (resp., a square matrix with length `n`) of zeros.
+creates a zero-degree polynomial which corresponds to a `m × n` matrix (resp., a column vector with length `n`) of zeros.
 
 ```
 casos.PS.ones(m,n)
 casos.PS.ones(n)
 ```
-creates a zero-degree polynomial which corresponds to a `m × n` matrix (resp., a square matrix with length `n`) of ones.
+creates a zero-degree polynomial which corresponds to a `m × n` matrix (resp., a column vector with length `n`) of ones.
 
 ```
 casos.PS.eye(n)
@@ -57,7 +57,7 @@ monomials(p)
 creates a `l × 1` vector of all monomials in the polynomial `p`; where `l` is the total number of monomials in `p`.
 
 #### Polynomials with symbolic coefficients
-Unlike indeterminate variables, symbolic variables can be decision variables of an optimization problem. The following syntax creates polynomials which have symbolic variables and as coefficients.
+Unlike indeterminate variables, symbolic variables can be decision variables of an optimization problem. The following syntax creates polynomials which have symbolic variables as coefficients. In all of the following syntaxes, the first argument corresponds to the display name (resp., prefix) for the symbolic coeffcients. See [Casadi's `SX` symbolics](https://web.casadi.org/docs/#the-sx-symbolics) for details.
 
 ```
 casos.PS.sym('c',w)
@@ -69,6 +69,30 @@ casos.PS.sym('c',w,[m n])
 casos.PS.sym('c',w,n)
 ```
 creates a `m × n` matrix (resp., a square matrix with length `n`) of polynomials with symbolic coefficients and monomials in `w`, where `w` must be a vector of monomials.
+
+```
+casos.PS.sym('c',[m n])
+casos.PS.sym('c',n)
+```
+creates a `m × n` matrix (resp., a square matrix with length `n`) of polynomials of degree zero; essentially, this is a symbolic matrix similar to `casadi.SX`.
+
+```
+casos.PS.sym(...,'gram')
+```
+where `...` denotes any of the syntaxes above, creates a scalar or matrix polynomial in Gram form, that is, with entries `p = z'*Q*z`, where `z` is the vector of monomials in `w` and `Q` is a quadratic symbolic matrix.
+
+**Note 1:** The syntax `casos.PS.sym('c',w,...)` creates polynomials with monomials *in* `w` and is therefore equivalent to `casos.PS.sym('c',monomials(w),...)`. In consequence, all of the following syntaxes yield the same result:
+```
+casos.PS.sym('c',[1;w])
+casos.PS.sym('c',[w;1])
+casos.PS.sym('c',[1;w;w])
+```
+
+**Note 2:** We say that a polynomial is *symbolic* if and only if all of its (nonzero) coefficients are symbols in the sense of Casadi. Except for the Gram form, all polynomials created with the syntaxes above are symbolic but the result of the notation 
+```
+casos.PS.sym('c',[1 2])*[x;x]
+```
+with `x = casos.PS('x')` would only be a symbolic *expression*. The same is true for the Gram form syntax because of the symmetries in the Gram matrix expression. The queries `is_symbolic`, `is_symexpr`, and `is_symgram` check whether a polynomial is a symbolic polynomial, a symbolic expression, or a symbolic Gram form, respectively.
 
 ## Functions between polynomials
 


### PR DESCRIPTION
This pull request extends the interface of polynomial expressions, resolves Issue #1, and fixes a number of errors not previously documented.

In particular:

1. The reversely graded reverse lexicographic order for monomials (i.e., `1 > x > y > z > x^2 > x*y > y^2 > x*z > y*z > z^2`) is introduced as canonical sorting, both for internal storage as well as if monomials are returned by the `monomial` function.
2. Selected properties of a subreference `p(i)` can be queried without evaluation the index reference first. These properties include minimum and maximum degree, number of terms and indeterminate variables, as well as the vectors of indeterminates and monomials.
3. Computation of the Gram basis for sum-of-squares constraints and decision variables, operating directly on vectors of polynomials.