### PR TITLE
Improve subs via coefficient sparsity

### DIFF
--- a/+casos/@PS/power.m
+++ b/+casos/@PS/power.m
@@ -70,16 +70,16 @@ elseif issorted(ja,'strictascend')
     % match exponents to unique degrees
     [dd,~,Ideg] = unique(deg);
     % repeat coefficients and degrees to match exponents
-    cfa = repmat(cfa,nen,1);
-    dga = repmat(dga,nen,1);
+    cfA = repmat(cfa,nen,1);
+    dgA = repmat(dga,nen,1);
     % match coefficients to corresponding monomials
-    [ia,ja] = get_triplet(sparsity(cfa)); % CasADi interface has 0-index
-    is_deg = ceil((ia(:)+1)./nva) == Ideg(ja(:)+1);
+    [ia,ja] = get_triplet(sparsity(cfA)); % CasADi interface has 0-index
+    is_deg = ceil((ia(:)+1)./nta) == Ideg(ja(:)+1);
     % select matching coefficients
-    S = casadi.Sparsity.triplet(size(cfa,1),size(cfa,2),ia(is_deg),ja(is_deg));
-    coeffs = project(cfa,S).^repmat(deg,nva*nen,1);
+    S = casadi.Sparsity.triplet(size(cfA,1),size(cfA,2),ia(is_deg),ja(is_deg));
+    coeffs = project(cfA,S).^repmat(deg,nta*nen,1);
     % multiply degree matrix with (unique) exponents
-    degmat = dga.*reshape(repmat(dd,nva,1),nen*nva,1);
+    degmat = dgA.*reshape(repmat(dd,nta,1),nen*nta,1);
 
 else
 % if nen > 1

--- a/+casos/@PS/private/evalMatrixOp.m
+++ b/+casos/@PS/private/evalMatrixOp.m
@@ -1,0 +1,17 @@
+function coeffs = evalMatrixOp(coeffs,op,dim)
+% Evaluate matrix operation along specified dimension.
+
+switch (dim)
+    case 'all'
+        % matrix operation over all elements
+        coeffs = op(coeffs,2);
+
+    case {1 2}
+        % matrix operation along dimension
+        coeffs = op(coeffs,dim);
+
+    otherwise
+        error('Invalid dimension input.')
+end
+
+end

--- a/+casos/@PS/private/finishMatrixOp.m
+++ b/+casos/@PS/private/finishMatrixOp.m
@@ -12,13 +12,16 @@ function coeffs = finishMatrixOp(coeffs,sz,dim)
 %
 % where each row of D corresponds to a term of the polynomial.
 
+if isequal(dim,'all')
+    % Matrix operation over all elements (scalar)
+    % nothing to do
+    return
+end
+
+% else:
 ne = size(coeffs,3-dim);
 
 switch (dim)
-    case 'all'
-        % Matrix operation over all elements (scalar)
-        % nothing to do
-
     case 1
         % Matrix operation along first dimension (row vector)
         % input is

--- a/+casos/@PS/private/removeZero.m
+++ b/+casos/@PS/private/removeZero.m
@@ -7,8 +7,10 @@ nel = size(coeffs,2);
 % remove degrees with zero coefficient
 [coeffs,degmat] = removeCoeffs(coeffs,degmat);
 
+if nargin > 2
 % remove unused variables
 [degmat, indets] = removeDegVar(degmat, indets);
+end
 
 % handle empty coeffient and/or degree matrix
 if length(coeffs) < 1

--- a/+casos/@PS/private/removeZero.m
+++ b/+casos/@PS/private/removeZero.m
@@ -32,13 +32,13 @@ function [coeffs,degmat] = removeCoeffs(coeffs,degmat)
     % sparsity pattern without zeros
     S0 = sparsity(sparsify(coeffs));
 
-    % detect full zeros
-    [~,iz] = setdiff(find(S1),find(S0));
-
     % nonzero coefficients with linear indices
-    [i0,~]  = ind2sub(size(coeffs),find(S0));   % sparse zeros
+    [i0,j0] = ind2sub(size(coeffs),find(S0));   % sparse zeros
     [i1,j1] = ind2sub(size(coeffs),find(S1));   % full zeros
     
+    % detect all-zero columns (full zero)
+    iz = ~ismember(j1,j0);
+
     % assign full zeros to first not all-sparse row
     i1(iz) = max([min(i0) 1]);
     

--- a/+casos/@PS/private/removeZero.m
+++ b/+casos/@PS/private/removeZero.m
@@ -34,25 +34,26 @@ function [coeffs,degmat] = removeCoeffs(coeffs,degmat)
 
     % nonzero coefficients with linear indices
     [i0,j0] = ind2sub(size(coeffs),find(S0));   % sparse zeros
-    [i1,j1] = ind2sub(size(coeffs),find(S1));   % full zeros
+    [~, j1] = ind2sub(size(coeffs),find(S1));   % full zeros
     
     % detect all-zero columns (full zero)
     iz = ~ismember(j1,j0);
 
     % assign full zeros to first not all-sparse row
-    i1(iz) = max([min(i0) 1]);
+    ii = [i0 repmat(max([min(i0) 1]),1,nnz(iz))];
+    jj = [j0 j1(iz)];
     
     % identify all-zero rows (zero coefficient)
-    [nr,~,ir] = unique(i1);
+    [nr,~,ir] = unique(ii);
 
     % coefficients without all-sparse rows
-    idx = unique(sub2ind(size(coeffs),i1,j1));
+    idx = unique(sub2ind(size(coeffs),ii,jj));
     
     % length corresponds to number of nonzero rows
     I = 1:length(nr);
     
     % sparsity pattern without all-sparse rows (note: 0-based index)
-    S = casadi.Sparsity.triplet(length(nr),size(coeffs,2),I(ir)-1,j1-1);
+    S = casadi.Sparsity.triplet(length(nr),size(coeffs,2),I(ir)-1,jj-1);
     % assign nonzero coefficients to sparsity pattern
     coeffs = casadi.SX(S,coeffs(idx));
 

--- a/+casos/@PS/private/uniqueDeg.m
+++ b/+casos/@PS/private/uniqueDeg.m
@@ -1,8 +1,10 @@
-function [coeffs,degmat] = uniqueDeg(coeffs,degmat,dim)
+function [coeffs,degmat] = uniqueDeg(coeffs,degmat)
 % Make degree matrix unique and return corresponding coefficients.
 %
 % This function ensures that the monomials are in graded REVERSE
 % lexicographic order.
+
+nt = size(coeffs,1);
 
 % sort by ascending degree
 degsum = sum(degmat,2);
@@ -10,38 +12,9 @@ degsum = sum(degmat,2);
 % make degree matrix unique
 [degmat2,id,ic] = unique([degsum fliplr(degmat)],'rows','sorted');
 
-if nargin < 3 || isempty(dim) || isequal('dim','all')
-    % default or matrix operation over all elements
-    % each row of the coefficient matrix corresponds to a term
-    nt = size(coeffs,1);
-
-    % sum coefficients for repeated terms
-    summat = sparse(ic,1:nt,1,length(id),nt);
-    coeffs = (summat*coeffs);
-
-elseif dim == 1
-    % each column of the coefficient matrix corresponds to a 
-    % column of a coefficient per term, sorted by terms
-    nc = size(coeffs,2);
-    nt = size(degmat,1);
-
-    % sum coefficient blocks for repeated terms
-    summat = sparse(1:nc,kron(ic(:),ones(nc/nt,1)),1,nc,length(id)*nc/nt);
-    coeffs = (coeffs*summat); %(summat*coeffs')';
-
-elseif dim == 2
-    % each row of the coefficient matrix corresponds to a 
-    % row of a coefficient per term, sorted by row index
-    nr = size(coeffs,1);
-    nt = size(degmat,1);
-
-    % sum coefficient rows for repeated terms
-    summat = sparse(kron(ones(nr/nt,1),ic(:)),1:nr,1,length(id)*nr/nt,nr);
-    coeffs = (summat*coeffs);
-
-else
-    error('Invalid dimension input.')
-end
+% sum repeated coefficients
+summat = sparse(ic,1:nt,1,length(id),nt);
+coeffs = sparsify(summat*coeffs);
 
 % reverse order of degrees
 degmat = fliplr(degmat2(:,2:end));

--- a/+casos/@PS/private/uniqueDeg.m
+++ b/+casos/@PS/private/uniqueDeg.m
@@ -1,10 +1,8 @@
-function [coeffs,degmat] = uniqueDeg(coeffs,degmat)
+function [coeffs,degmat] = uniqueDeg(coeffs,degmat,dim)
 % Make degree matrix unique and return corresponding coefficients.
 %
 % This function ensures that the monomials are in graded REVERSE
 % lexicographic order.
-
-nt = size(coeffs,1);
 
 % sort by ascending degree
 degsum = sum(degmat,2);
@@ -12,9 +10,38 @@ degsum = sum(degmat,2);
 % make degree matrix unique
 [degmat2,id,ic] = unique([degsum fliplr(degmat)],'rows','sorted');
 
-% sum repeated coefficients
-summat = sparse(ic,1:nt,1,length(id),nt);
-coeffs = (summat*coeffs);
+if nargin < 3 || isempty(dim) || isequal('dim','all')
+    % default or matrix operation over all elements
+    % each row of the coefficient matrix corresponds to a term
+    nt = size(coeffs,1);
+
+    % sum coefficients for repeated terms
+    summat = sparse(ic,1:nt,1,length(id),nt);
+    coeffs = (summat*coeffs);
+
+elseif dim == 1
+    % each column of the coefficient matrix corresponds to a 
+    % column of a coefficient per term, sorted by terms
+    nc = size(coeffs,2);
+    nt = size(degmat,1);
+
+    % sum coefficient blocks for repeated terms
+    summat = sparse(1:nc,kron(ic(:),ones(nc/nt,1)),1,nc,length(id)*nc/nt);
+    coeffs = (coeffs*summat); %(summat*coeffs')';
+
+elseif dim == 2
+    % each row of the coefficient matrix corresponds to a 
+    % row of a coefficient per term, sorted by row index
+    nr = size(coeffs,1);
+    nt = size(degmat,1);
+
+    % sum coefficient rows for repeated terms
+    summat = sparse(kron(ones(nr/nt,1),ic(:)),1:nr,1,length(id)*nr/nt,nr);
+    coeffs = (summat*coeffs);
+
+else
+    error('Invalid dimension input.')
+end
 
 % reverse order of degrees
 degmat = fliplr(degmat2(:,2:end));

--- a/+casos/@PS/private/uniqueDeg.m
+++ b/+casos/@PS/private/uniqueDeg.m
@@ -14,7 +14,7 @@ degsum = sum(degmat,2);
 
 % sum repeated coefficients
 summat = sparse(ic,1:nt,1,length(id),nt);
-coeffs = sparsify(summat*coeffs);
+coeffs = (summat*coeffs);
 
 % reverse order of degrees
 degmat = fliplr(degmat2(:,2:end));

--- a/+casos/@PS/prod.m
+++ b/+casos/@PS/prod.m
@@ -21,7 +21,8 @@ if isempty(A)
     B = casos.PS.ones(sz);
     return
 
-elseif size(A,dim) == 1
+elseif isequal(dim,'all') && isscalar(A) ...
+        || ~isequal(dim,'all') && size(A,dim) == 1
     % nothing to do
     B = A;
     return
@@ -30,73 +31,14 @@ end
 % else:
 B = casos.PS;
 
-nt = A.nterm;
-nv = A.nvars;
-
 % reshape input coefficient matrix
 [cfa,sz] = prepareMatrixOp(A.coeffs,A.matdim,dim);
 
 % multiply entries
-L = numel(A)/prod(sz);
-nb = prod(sz);
-% (sum_a c_a[1]*x^a).* ... .* (sum_a c_a[L]*x^a)
-%  = sum_a1 ... sum_aL (c_a1[1].* ... .* c_aL[L])*x^(a1+...+aL)
-I = cell(1,L);
-[I{:}] = ndgrid(1:nt); I = cellfun(@(c) c(:),I,'UniformOutput',false);
-idx = horzcat(I{:});
-
-% permute degree matrix
-%
-%       | dax ... day |      | da1x ... da1y        |
-%   D = |  :       :  |  ->  |   :        :     ... |
-%       | dzx ... dzy |      | daLx ... daLy        |
-%
-dga = reshape(A.degmat(idx',:),L,nv*nt^L);
-% combine degrees
-dgb = sum(dga,1);
-
-% permute and combine coefficients matrix
-% for details on cfa, see PREPAREMATRIXOP
-switch (dim)
-    case 'all'
-        % compute total product
-        % rows are elements of coefficients c_a
-        row = idx;              % select coefficient
-        col = repmat(1:L,nt^L,1);   % select element
-        ind = sub2ind(size(cfa),row,col);
-        C = reshape(cfa(ind),nt^L,L);
-
-        % combine coefficients
-        cfb = sx_prod(C,2);
-
-    case 2
-        % compute product along second dimension
-        % rows are rows of c_a, sorted by term
-        row = kron((0:nb-1)',nt*ones(nt^L,L)) + repmat(idx,nb,1);
-        col = repmat(1:L,nb*nt^L,1);    % select row
-        ind = sub2ind(size(cfa),row,col);
-        C = reshape(cfa(ind),nb*nt^L,L);
-
-        % combine coefficients
-        cfb = sx_prod(C,2);
-
-    case 1
-        % compute product along first dimension
-        % columns are colums of c_a, sorted by coefficient
-        term0 = nb*(0:nt-1)';
-        row = repmat(1:L,nb*nt^L,1);    % select column
-        col = kron(term0(idx),ones(nb,1)) + repmat((1:nb)',nt^L,L);
-        ind = sub2ind(size(cfa),row,col);
-        C = reshape(cfa(ind'),L,nb*nt^L);
-
-        % combine coefficients
-        cfb = sx_prod(C,1);
-end
+[cfb,degmat] = prod_internal(cfa,A.degmat,dim,numel(A)/prod(sz),prod(sz));
 
 % reshape output coefficient matrix
 coeffs = finishMatrixOp(cfb,sz,dim);
-% reshape output degree matrix
-degmat = reshape(dgb,nt^L,nv);
 
 % make degree matrix unique
 [coeffs,degmat] = uniqueDeg(coeffs, degmat);
@@ -109,5 +51,111 @@ B.coeffs = coeffs;
 B.degmat = degmat;
 B.indets = indets;
 B.matdim = sz;
+
+end
+
+function [coeffs,degmat] = prod_internal(coeffs,degmat,dim,L,nb)
+% Compute product of matrix elements.
+
+nt = size(degmat,1);
+
+if L <= 1
+    % nothing to do
+
+elseif L == 2 || (L*nt^L) > 1e6
+    % two elements to multiply or
+    % number of permutations exceeds memory
+    L1 = ceil(L/2);
+    L2 = L - L1;
+    % divide and conquer
+    switch (dim)
+        case {2 'all'}
+            % compute product along second dimension
+            cfs = mat2cell(coeffs,nb*nt,[L1 L2]);
+
+        case 1
+            % compute product along first dimension
+            cfs = mat2cell(coeffs,[L1 L2],nb*nt);
+    end
+    % compute partial products
+    [cfa,dga] = prod_internal(cfs{1},degmat,dim,L1,nb);
+    [cfb,dgb] = prod_internal(cfs{2},degmat,dim,L2,nb);
+
+    nta = size(dga,1);
+    ntb = size(dgb,1);
+
+    % multiply partial products
+    % see TIMES for details
+    switch (dim)
+        case {2 'all'}
+            % multiply rows
+            coeffs = kron(cfa,ones(ntb,1)) .* kron(ones(nta,1),cfb);
+
+        case 1
+            % multiply columns
+            coeffs = kron(cfa,ones(1,ntb)) .* kron(ones(1,nta),cfb);
+    end
+    degmat = kron(dga,ones(ntb,1)) +  kron(ones(nta,1),dgb);
+
+else
+    % (sum_a c_a[1]*x^a).* ... .* (sum_a c_a[L]*x^a)
+    %  = sum_a1 ... sum_aL (c_a1[1].* ... .* c_aL[L])*x^(a1+...+aL)
+    I = cell(1,L);
+    [I{:}] = ndgrid(1:nt); I = cellfun(@(c) c(:),I,'UniformOutput',false);
+    idx = horzcat(I{:});
+
+    nv = size(degmat,2);
+    
+    % permute degree matrix
+    %
+    %       | dax ... day |      | da1x ... da1y        |
+    %   D = |  :       :  |  ->  |   :        :     ... |
+    %       | dzx ... dzy |      | daLx ... daLy        |
+    %
+    dga = reshape(degmat(idx',:),L,nv*nt^L);
+    % combine degrees
+    dgb = sum(dga,1);
+    
+    % permute and combine coefficients matrix
+    % for details on cfa, see PREPAREMATRIXOP
+    switch (dim)
+        case 'all'
+            % compute total product
+            % rows are elements of coefficients c_a
+            row = idx;              % select coefficient
+            col = repmat(1:L,nt^L,1);   % select element
+            ind = sub2ind(size(coeffs),row,col);
+            C = reshape(coeffs(ind),nt^L,L);
+    
+            % combine coefficients
+            coeffs = sx_prod(C,2);
+    
+        case 2
+            % compute product along second dimension
+            % rows are rows of c_a, sorted by term
+            row = kron((0:nb-1)',nt*ones(nt^L,L)) + repmat(idx,nb,1);
+            col = repmat(1:L,nb*nt^L,1);    % select row
+            ind = sub2ind(size(coeffs),row,col);
+            C = reshape(coeffs(ind),nb*nt^L,L);
+    
+            % combine coefficients
+            coeffs = sx_prod(C,2);
+    
+        case 1
+            % compute product along first dimension
+            % columns are colums of c_a, sorted by coefficient
+            term0 = nb*(0:nt-1)';
+            row = repmat(1:L,nb*nt^L,1);    % select column
+            col = kron(term0(idx),ones(nb,1)) + repmat((1:nb)',nt^L,L);
+            ind = sub2ind(size(coeffs),row,col);
+            C = reshape(coeffs(ind'),L,nb*nt^L);
+    
+            % combine coefficients
+            coeffs = sx_prod(C,1);
+    end
+    
+    % reshape output degree matrix
+    degmat = reshape(dgb,nt^L,nv);
+end
 
 end

--- a/+casos/@PS/prod.m
+++ b/+casos/@PS/prod.m
@@ -41,7 +41,7 @@ B = casos.PS;
 coeffs = finishMatrixOp(cfb,sz,dim);
 
 % make degree matrix unique
-[coeffs,degmat] = uniqueDeg(coeffs, degmat);
+% [coeffs,degmat] = uniqueDeg(coeffs, degmat);
 
 % remove zero terms
 [coeffs,degmat,indets] = removeZero(coeffs,degmat,A.indets);
@@ -61,6 +61,7 @@ nt = size(degmat,1);
 
 if L <= 1
     % nothing to do
+    return
 
 elseif L == 2 || (L*nt^L) > 1e6
     % two elements to multiply or
@@ -157,5 +158,8 @@ else
     % reshape output degree matrix
     degmat = reshape(dgb,nt^L,nv);
 end
+
+% make degree matrix unique
+[coeffs,degmat] = uniqueDeg(coeffs, degmat, dim);
 
 end

--- a/+casos/@PS/prod.m
+++ b/+casos/@PS/prod.m
@@ -31,17 +31,96 @@ end
 % else:
 B = casos.PS;
 
+nt = A.nterm;
+nv = A.nvars;
+ne = A.numel;
+sz = A.matdim;
+
+% check number of coefficients per matrix component
+idx = find(sparsity(A.coeffs));
+[ia,ja] = ind2sub(size(A.coeffs),idx);
+
+if nt == 1 
+    % polynomial is a constant matrix 
+    % or prod(a) = prod(c)*(x^d)^L
+    
+    % reshape input coefficient matrix
+    [cfa,sz] = prepareMatrixOp(A.coeffs,sz,dim);
+
+    % multiply entries of coefficient
+    cfb = evalMatrixOp(cfa,@sx_prod,dim);
+
+    % reshape output coefficient matrix
+    coeffs = finishMatrixOp(cfb,sz,dim);
+
+    % number of entries to multiply
+    L = ne/prod(sz);
+    % multiply degrees (if any)
+    degmat = L*A.degmat;
+
+elseif issorted(ja,'strictascend')
+    % polynomial is a matrix of monomials
+    % match degrees to nonzero coefficients
+    dga = sparse(ne,nv);
+    dga(ja,:) = A.degmat(ia,:);
+
+    % combine degrees
+    switch (dim)
+        case 'all'
+            % matrix operation over all elements
+            % sum all degrees
+            degmat = sum(dga,1);
+
+        case 1
+            % matrix operation along first dimension
+            dgb = reshape(dga,sz(1),sz(2)*nv);
+            % sum degrees columnwise
+            dgc = sum(dgb,1);
+            % reshape to degree matrix
+            degmat = reshape(dgc,sz(2),nv);
+
+        case 2
+            % matrix operation along second dimension
+            dgb = reshape(dga',sz(1)*nv,sz(2));
+            % sum degrees rowwise
+            dgc = sum(dgb,2);
+            % reshape to degree matrix
+            degmat = reshape(dgc,nv,sz(1))';
+
+        otherwise
+            error('Invalid dimension input')
+    end
+
+    % combine coefficients
+    coeff = sum(A.coeffs,1);
+
+    % reshape input coefficient matrix
+    [cfa,sz] = prepareMatrixOp(coeff,sz,dim);
+
+    % multiply coefficients
+    cfb = evalMatrixOp(cfa,@sx_prod,dim);
+
+    % expand to coefficient matrix
+    coeffs = diag(cfb);
+
+    % make degree matrix unique
+    [coeffs,degmat] = uniqueDeg(coeffs, degmat);
+
+else
+
 % reshape input coefficient matrix
-[cfa,sz] = prepareMatrixOp(A.coeffs,A.matdim,dim);
+[cfa,sz] = prepareMatrixOp(A.coeffs,sz,dim);
+
+% number of entries to multiply
+L = ne/prod(sz);
 
 % multiply entries
-[cfb,degmat] = prod_internal(cfa,A.degmat,dim,numel(A)/prod(sz),prod(sz));
+[cfb,degmat] = prod_internal(cfa,A.degmat,dim,L,prod(sz));
 
 % reshape output coefficient matrix
 coeffs = finishMatrixOp(cfb,sz,dim);
 
-% make degree matrix unique
-% [coeffs,degmat] = uniqueDeg(coeffs, degmat);
+end
 
 % remove zero terms
 [coeffs,degmat,indets] = removeZero(coeffs,degmat,A.indets);
@@ -96,6 +175,7 @@ elseif L == 2 || (L*nt^L) > 1e6
             % multiply columns
             coeffs = kron(cfa,ones(1,ntb)) .* kron(ones(1,nta),cfb);
     end
+    % combine degrees (see TIMES)
     degmat = kron(dga,ones(ntb,1)) +  kron(ones(nta,1),dgb);
 
 else
@@ -153,6 +233,9 @@ else
     
             % combine coefficients
             coeffs = sx_prod(C,1);
+
+        otherwise
+            error('Invalid dimension input.')
     end
     
     % reshape output degree matrix

--- a/+casos/@PS/simplify.m
+++ b/+casos/@PS/simplify.m
@@ -1,0 +1,16 @@
+function b = simplify(a)
+% Simplify symbolic expressions.
+
+coeffs = simplify(a.coeffs);
+
+% remove zero terms
+[coeffs,degmat,indets] = removeZero(coeffs,a.degmat,a.indets);
+
+% new polynomial
+b = casos.PS;
+b.coeffs = coeffs;
+b.degmat = degmat;
+b.indets = indets;
+b.matdim = a.matdim;
+
+end

--- a/+casos/@PS/sparsify.m
+++ b/+casos/@PS/sparsify.m
@@ -1,0 +1,16 @@
+function b = sparsify(a)
+% Sparsify symbolic expressions.
+
+coeffs = sparsify(a.coeffs);
+
+% remove zero terms
+[coeffs,degmat,indets] = removeZero(coeffs,a.degmat,a.indets);
+
+% new polynomial
+b = casos.PS;
+b.coeffs = coeffs;
+b.degmat = degmat;
+b.indets = indets;
+b.matdim = a.matdim;
+
+end

--- a/+casos/@PS/str.m
+++ b/+casos/@PS/str.m
@@ -8,18 +8,25 @@ end
 
 % else
 out = cell(size(obj));
+% preassign sparse zeros
+out(:) = {'00'};
+
+% coefficient sparsity
+S = sparsity(obj.coeffs);
+% nonzero coefficients
+[iterms,ielems] = ind2sub(size(obj.coeffs),find(S));
 
 % iterate over elements
-for i = 1:numel(obj)
+for ie = unique(ielems)
     % polynomial terms (monomials)
     terms = cell(1,obj.nterm);
 
     firstterm = 1;
 
-    for j = 1:obj.nterm
+    for it = iterms(ielems == ie)
         % coefficient & degree
-        cf = obj.coeffs(j,i);
-        dg = obj.degmat(j,:);
+        cf = obj.coeffs(it,ie);
+        dg = obj.degmat(it,:);
 
         % string representation of coefficient and sign
         mdf = '';
@@ -41,8 +48,9 @@ for i = 1:numel(obj)
             sgn = ' - ';
             mdf = '-';
         else
-            % zero constant
-            continue;
+            % zero constant (nonsparse zero)
+            scf = '0';
+            sgn = ' + ';
         end
 
         % remove sign on first term
@@ -71,15 +79,14 @@ for i = 1:numel(obj)
         end
 
         % combine
-        terms{j} = [sgn scf monom];
+        terms{it} = [sgn scf monom];
     end
 
     % check for zero polynomial
-    if firstterm
-        out{i} = '0';
-    else
-        out{i} = [terms{:}];
-    end
+    assert(~firstterm, 'Notify developers.')
+    
+    % combine terms 
+    out{ie} = [terms{:}];
 end
 
 end

--- a/+casos/@PS/str.m
+++ b/+casos/@PS/str.m
@@ -93,7 +93,7 @@ for ic = find(S)
 end
 
 % combine terms 
-out(~firstterm) = join(terms(:,~firstterm)', '');
+out(~firstterm) = join(terms(:,~firstterm)', '', 2);
 % assign sparse zeros
 out(firstterm) = {'00'};
 

--- a/+casos/@PS/subs.m
+++ b/+casos/@PS/subs.m
@@ -48,9 +48,6 @@ if is_zerodegree(b)
     % compute exponents b^a1
     B = sx_prod(b.^deg0,2);
 
-    % retain constant monomials (work around)
-    B(find(all(deg0==0,2))) = 1; %#ok<FNDSB> 
-
     % coefficients of c = sum_a c_a*b^a1*y^a2
     coeffs = a.coeffs.*B;
     % degree matrix of c 

--- a/+casos/@PS/sum.m
+++ b/+casos/@PS/sum.m
@@ -29,14 +29,7 @@ B = casos.PS;
 [cfa,sz] = prepareMatrixOp(A.coeffs,A.matdim,dim);
 
 % sum coefficients
-switch (dim)
-    case 'all'
-        % compute total sum of each coefficient
-        cfb = sum(cfa,2);
-    otherwise
-        % compute sum of coefficient along dimension
-        cfb = sum(cfa,dim);
-end
+evalMatrixOp(cfa,@sum,dim);
 
 % reshape output coefficient matrix
 coeffs = finishMatrixOp(cfb,sz,dim);

--- a/demo/test_subs.m
+++ b/demo/test_subs.m
@@ -1,0 +1,34 @@
+clc
+clear
+
+%% define variables
+x = casos.PS('x',6,1);
+u = casos.PS('u',3,1);
+
+
+x1 = x(1); 
+x2 = x(2); 
+x3 = x(3); 
+x4 = x(4);
+x5 = x(5);
+x6 = x(6);
+
+J = diag([8970;9230;3830]);% Casini Parameter
+
+% skew-symmetric matrix
+skew = @(x) [   0  -x(3)  x(2); 
+              x(3)   0   -x(1); 
+             -x(2)  x(1)   0 ];
+
+
+B = @(sigma) (1-sigma'*sigma)*eye(3)+skew(sigma)+ 2*sigma*sigma';
+
+% dynamics
+x_dot =  [-inv(J)*skew(x(1:3))*J*x(1:3) + inv(J)*u; % omega_dot
+           1/4*B(x(4:6))*x(1:3)];                     % MRP kinematics
+
+% just for testing set to identity matrices
+Dx = eye(6);
+Du = eye(3);
+
+f_scaled = Dx*subs(x_dot,[x;u],[Dx^-1*x;Du^-1*u])


### PR DESCRIPTION
This PR improves the implementation of `subs` and related operations to resolve issues #28 and #29:

1. Class `PS` now distinguishes between full and sparse zeros; for a zero polynomial, only the lowest-degree zero coefficients is stored as full zero.
2. Function `prod` resorts to a recursion if the number of permutations exceeds a certain limit (currently 1M).

On a related note, function `str` now iterates over nonzero coefficients only.