### PR TITLE
Resolve issue with SCS solver interface.

### DIFF
--- a/+casos/+package/+solvers/@SCSInterface/SCSInterface.m
+++ b/+casos/+package/+solvers/@SCSInterface/SCSInterface.m
@@ -42,6 +42,13 @@ methods
     end
 end
 
+methods (Static, Access=protected)
+    %% Static helper functions
+    % MOSEK/SCS-style for the semidefinite cone
+    V = sdp_vec(M,varargin);
+    M = sdp_mat(V,varargin);
+end
+
 methods (Access=protected)
     buildproblem(obj);
 end

--- a/+casos/+package/+solvers/@SCSInterface/sdp_mat.m
+++ b/+casos/+package/+solvers/@SCSInterface/sdp_mat.m
@@ -1,0 +1,47 @@
+function M = sdp_mat(V,scale)
+% MOSEK/SCS-style matrix de-vectorization for semidefinite cone embedding.
+%
+% This function takes a matrix
+% 
+%   V = [ v1 ... vl ]
+% 
+% where each column is a k*(k+1)/2-by-1 vector that corresponds to stacking 
+% the lower-triangular elements of a k-by-k symmetric matrix Mi 
+% column-wise, where the off-diagonal entries are scaled by sqrt(2), and 
+% returns the matrix
+%
+%   M = [ m1 ... ml ]
+%
+% where each column satisfies mi = Mi(:).
+
+k = (sqrt(8*size(V,1) + 1) - 1)/2;
+
+assert(k == floor(k), 'Input must be a compatible vector.')
+
+% user-defined scaling
+if nargin < 2
+    scale = sqrt(2);
+end
+
+% select lower-triangular elements
+s = casadi.Sparsity.lower(k);
+S = repmat(reshape(s,k^2,1),1,size(V,2));
+
+% assign elements column-wise
+Msc = feval(class(V),S,V(:));
+
+% select diagonal entries
+Id = find(casadi.Sparsity.diag(k));
+
+% indices
+[i,j] = ind2sub([k k],1:k^2);
+% transpose
+idx = sub2ind([k k],j,i);
+
+% mirror off-diagonal lower-triangular entries,
+% note: this ensures output is symmetric
+% de-scale off-diagonal entries
+M = scale\(Msc(idx,:) + Msc);
+M(Id,:) = M(Id,:) + (1 - 2/scale)*Msc(Id,:);
+
+end

--- a/+casos/+package/+solvers/@SCSInterface/sdp_vec.m
+++ b/+casos/+package/+solvers/@SCSInterface/sdp_vec.m
@@ -1,0 +1,45 @@
+function V = sdp_vec(M,scale)
+% MOSEK/SCS-style matrix vectorization for semidefinite cone embedding.
+%
+% This function takes a matrix
+%
+%   M = [ m1 ... ml ]
+%
+% where each column satisfies mi = Mi(:) for some k-by-k matrix Mi, and
+% returns the matrix
+%
+%   V = [ v1 ... vl ]
+%
+% where each column is a k*(k+1)/2-by-1 vector that corresponds to stacking 
+% the lower-triangular elements of Mi column-wise, where the off-diagonal 
+% entries are scaled by sqrt(2).
+
+k = sqrt(size(M,1));
+
+assert(k == floor(k), 'Input must be a quadratic matrix.')
+
+% user-defined scaling
+if nargin < 2
+    scale = sqrt(2);
+end
+
+% indices
+[i,j] = ind2sub([k k],1:k^2);
+% transpose
+idx = sub2ind([k k],j,i);
+% ensure matrix is symmetric
+M = (M(idx,:) + M)/2;
+
+% select diagonal entries
+Id = find(casadi.Sparsity.diag(k));
+% lower-triangular entries
+Il = find(casadi.Sparsity.lower(k));
+
+% scale lower-triangular off-diagonal entries, 
+Msc = scale*M;
+Msc(Id,:) = Msc(Id,:) + (1-scale)*M(Id,:);
+
+% stack elements column-wise
+V = Msc(Il,:); %#ok<FNDSB> % logical indexing not supported by CasADi
+
+end


### PR DESCRIPTION
This PR fixes an issue with the SCS solver interface caused by SCS-style vectorization of LMIs (Issue #64).