### PR TITLE
Linear operators and polynomial functions

### DIFF
--- a/+casos/+package/+core/@AbstractOperator/AbstractOperator.m
+++ b/+casos/+package/+core/@AbstractOperator/AbstractOperator.m
@@ -45,7 +45,7 @@ methods
             assert(nargin < 3, 'Too many arguments.')
 
             S = M;
-            M = obj.new_matrix(matrix_sparsity(S),varargin{:});
+            M = obj.new_matrix(project(varargin{:},matrix_sparsity(S)));
 
         else
             S = casos.package.core.OperatorSparsity(sparsity(M),varargin{:});

--- a/+casos/+package/+core/@AbstractOperator/op2basis.m
+++ b/+casos/+package/+core/@AbstractOperator/op2basis.m
@@ -1,33 +1,31 @@
-function [M,Si,So] = op2basis(op,Si,So)
+function [M,S] = op2basis(op,S)
 % Return a matrix of nonzero coordinates for given input and output basis
 % (sparsity). If no basis is given, the operator's sparsity patterns are
 % used.
 
 if nargin < 2
     % return nonzero coordinates
-    Si = op.sparsity_in;
-    So = op.sparsity_out;
+    S = sparsity(op);
     M = op.matrix;
     return
 end
 
 % else
-assert(nargin == 3,'Undefined syntax.')
-assert(isequal(size(Si),size(op.sparsity_in)),'Input dimensions must not change.')
-assert(isequal(size(So),size(op.sparsity_out)),'Output dimensions must not change.')
+assert(isequal(size_in(S),size_in(op)),'Input dimensions must not change.')
+assert(isequal(size_out(S),size_out(op)),'Output dimensions must not change.')
 
 % join input/output nonzero coordinates
-[Si2,Iin] = op_join(op.sparsity_in,Si);
-[So2,Iout] = op_join(op.sparsity_out,So);
+[Si2,Iin] = op_join(op.sparsity_in,S.sparsity_in);
+[So2,Iout] = op_join(op.sparsity_out,S.sparsity_out);
 
 % expand matrix to joint nonzeros
 M0 = expand(op.matrix,[nnz(So2) nnz(Si2)],Iin,Iout);
 
 % find common nonzero coordinates
-[~,I1,~] = op_intersect(Si2,Si);
-[~,~,I2] = op_intersect(So,So2);
+[~,I1,~] = op_intersect(Si2,S.sparsity_in);
+[~,~,I2] = op_intersect(S.sparsity_out,So2);
 
 % return nonzeros
-M = M0(I2,I1);
+M = project(M0(I2,I1),matrix_sparsity(S));
 
 end

--- a/+casos/+package/+core/OperatorSparsity.m
+++ b/+casos/+package/+core/OperatorSparsity.m
@@ -1,0 +1,177 @@
+classdef (InferiorClasses = {?casadi.Sparsity, ?casadi.DM, ?casadi.SX, ?casadi.MX}) ...
+    OperatorSparsity < casos.package.core.PolynomialInterface
+% Operator sparsity class.
+
+properties (Access=protected)
+    % sparsity of linear map from in-nnz to out-nnz
+    sparsity_M = casadi.Sparsity;
+end
+
+properties (SetAccess=private,GetAccess=public)
+    % polynomial sparsity patterns of input and output
+    sparsity_in = casos.Sparsity;
+    sparsity_out = casos.Sparsity;
+end
+
+methods
+    %% Public constructor
+    function obj = OperatorSparsity(S,Si,So)
+        % New operator sparsity pattern.
+        if nargin < 1
+            % nothing to do (null)
+
+        elseif isa(S,'casos.package.core.OperatorSparsity')
+            % copy operator pattern
+            Si = casos.Sparsity(S.sparsity_in);
+            So = casos.Sparsity(S.sparsity_out);
+            S = S.sparsity_M;
+
+        elseif nargin < 2
+            % matrix multiplication pattern
+            Si = casos.Sparsity.dense(size(M,2),1);
+            So = casos.Sparsity.dense(size(M,1),1);
+
+        elseif nargin < 3
+            % dual operator pattern
+            Si = casos.Sparsity(Si);
+            So = casos.Sparsity.dense(size(M,1),1);
+
+        elseif nargin < 4
+            % construct operator pattern
+            Si = casos.Sparsity(Si);
+            So = casos.Sparsity(So);
+
+        else
+            error('Undefined syntax.')
+        end
+
+        assert(size(S,2) == nnz(Si), 'Input dimensions mismatch.')
+        assert(size(S,1) == nnz(So), 'Output dimensions mismatch.')
+
+        obj.sparsity_M = casadi.Sparsity(S);
+        obj.sparsity_in = Si;
+        obj.sparsity_out = So;
+    end
+
+    %% Getter
+    function varargout = size(obj,varargin)
+        % Return size of operator.
+        [varargout{1:nargout}] = size(sparse(obj.numel_out,obj.numel_in),varargin{:});
+    end
+
+    function sz = size_in(obj,varargin)
+        % Return input size.
+        sz = size(obj.sparsity_in,varargin{:});
+    end
+
+    function sz = size_out(obj,varargin)
+        % Return output size.
+        sz = size(obj.sparsity_out,varargin{:});
+    end
+
+    function n = numel_in(obj)
+        % Return number of input elements.
+        n = numel(obj.sparsity_in);
+    end
+
+    function n = numel_out(obj)
+        % Return number of output elements.
+        n = numel(obj.sparsity_out);
+    end
+
+    function n = nnz_in(obj)
+        % Return number input nonzeros.
+        n = nnz(obj.sparsity_in);
+    end
+
+    function n = nnz_out(obj)
+        % Return number of output nonzeros.
+        n = nnz(obj.sparsity_out);
+    end
+
+    function n = nterm_in(obj)
+        % Return number of input terms.
+        n = nterm(obj.sparsity_in);
+    end
+
+    function n = nterm_out(obj)
+        % Return number of output terms.
+        n = nterm(obj.sparsity_out);
+    end
+
+    function tf = isrow(obj)
+        % Check if operator is a row vector.
+        tf = (size(obj,1) == 1);
+    end
+
+    function tf = iscolumn(obj)
+        % Check if operator is a column vector.
+        tf = (size(obj,2) == 1);
+    end
+
+    function tf = isvector(obj)
+        % Check if operator is a vector.
+        tf = any(size(obj) == 1);
+    end
+
+    function tf = isscalar(obj)
+        % Check if operator is a scalar.
+        tf = all(size(obj) == 1);
+    end
+
+    function tf = is_zerodegree(obj)
+        % Check if operator is of input/output degree zero.
+        tf = (obj.sparsity_in.maxdeg == 0 && obj.sparsity_out.maxdeg == 0);
+    end
+
+    function tf = is_matrix(obj)
+        % Check if operator is mapping between vectors.
+        tf = (iscolumn(obj.sparsity_in) && iscolumn(obj.sparsity_out));
+    end
+
+    function tf = is_polynomial(obj)
+        % Check if operator corresponds to multiplication with polynomial.
+        tf = (is_zerodegree(obj.sparsity_in) && obj.numel_in == 1);
+    end
+
+    function tf = is_dual(obj)
+        % Check if operator is a linear form (dual).
+        tf = (is_zerodegree(obj.sparsity_out) && obj.numel_out == 1);
+    end
+
+    function tf = is_equal(obj,op)
+        % Check if operators are equal.
+        tf = is_equal(obj.sparsity_in,op.sparsity_in) ...
+            && is_equal(obj.sparsity_out,op.sparsity_out) ...
+            && is_equal(obj.sparsity_M,op.sparsity_M);
+    end
+
+    function tf = is_wellposed(obj)
+        % Check if operator is well formed.
+        tf = is_wellformed(obj.sparsity_in) ...
+            && is_wellformed(obj.sparsity_out) ...
+            && size(obj.sparsity_M,1) == obj.numel_out ...
+            && size(obj.sparsity_M,2) == obj.numel_in;
+    end
+
+    %% Display output
+    function s = str(obj)
+        % Return string representation.
+        s = compose('[%s]->[%s],%dnz',to_char(obj.sparsity_in),to_char(obj.sparsity_out),nnz(obj.sparsity_M));
+    end
+
+    function print_matrix(obj)
+        % Print operator matrix pattern.
+        disp(obj.sparsity_M)
+    end
+end
+
+methods (Access={?casos.package.core.PolynomialInterface})
+    %% Friend class interface
+    function S = matrix_sparsity(obj)
+        % Return sparsity pattern of linear map.
+        S = casadi.Sparsity(obj.sparsity_M);
+    end
+end
+
+end

--- a/+casos/+package/+core/OperatorSparsity.m
+++ b/+casos/+package/+core/OperatorSparsity.m
@@ -1,4 +1,4 @@
-classdef (InferiorClasses = {?casadi.Sparsity, ?casadi.DM, ?casadi.SX, ?casadi.MX}) ...
+classdef (InferiorClasses = {?casadi.Sparsity, ?casadi.DM, ?casadi.SX, ?casadi.MX, ?casos.PD, ?casos.PS}) ...
     OperatorSparsity < casos.package.core.PolynomialInterface
 % Operator sparsity class.
 
@@ -28,13 +28,13 @@ methods
 
         elseif nargin < 2
             % matrix multiplication pattern
-            Si = casos.Sparsity.dense(size(M,2),1);
-            So = casos.Sparsity.dense(size(M,1),1);
+            Si = casos.Sparsity.dense(size(S,2),1);
+            So = casos.Sparsity.dense(size(S,1),1);
 
         elseif nargin < 3
             % dual operator pattern
             Si = casos.Sparsity(Si);
-            So = casos.Sparsity.dense(size(M,1),1);
+            So = casos.Sparsity.dense(size(S,1),1);
 
         elseif nargin < 4
             % construct operator pattern
@@ -154,10 +154,27 @@ methods
             && size(obj.sparsity_M,2) == obj.numel_in;
     end
 
+    %% Extended interface
+    function varargout = poly2basis(M,S)
+        % Fall back to operator.
+        [varargout{1:nargout}] = op2basis(casos.package.operator(M),S);
+    end
+
+    function varargout = op2basis(M,S)
+        % Fall back to operator.
+        [varargout{1:nargout}] = op2basis(casos.package.operator(M),S);
+    end
+
     %% Display output
     function s = str(obj)
         % Return string representation.
         s = compose('[%s]->[%s],%dnz',to_char(obj.sparsity_in),to_char(obj.sparsity_out),nnz(obj.sparsity_M));
+    end
+
+    function s = signature(obj)
+        % Return signature.
+        in = signature(obj.sparsity_in); out = signature(obj.sparsity_out);
+        s = compose('(%s)->(%s),%dnz',in{:},out{:},nnz(obj.sparsity_M));
     end
 
     function print_matrix(obj)

--- a/+casos/+package/+functions/@FunctionWrapper/FunctionWrapper.m
+++ b/+casos/+package/+functions/@FunctionWrapper/FunctionWrapper.m
@@ -173,6 +173,11 @@ methods
         tf = has_option(obj.wrap,name);
     end
 
+    function J = jacobian(obj)
+        % Return Jacobian if supported.
+        J = jacobian(obj.wrap);
+    end
+
     function out = call(obj,args)
         % Evaluate function for given arguments.
         assert(~is_null(obj), 'Notify the developers.')

--- a/+casos/+package/+functions/@FunctionWrapper/parse_argument.m
+++ b/+casos/+package/+functions/@FunctionWrapper/parse_argument.m
@@ -10,8 +10,17 @@ elseif isa(expr,'casadi.SX')
 elseif isa(expr,'casadi.MX')
     type = casos.package.functions.FunctionArgumentType.MX;
 
+elseif isa(expr,'casos.PD')
+    type = casos.package.functions.FunctionArgumentType.PD;
+
 elseif isa(expr,'casos.PS')
     type = casos.package.functions.FunctionArgumentType.PS;
+
+elseif isa(expr,'casos.PDOperator')
+    type = casos.package.functions.FunctionArgumentType.PDOperator;
+
+elseif isa(expr,'casos.PSOperator')
+    type = casos.package.functions.FunctionArgumentType.PSOperator;
 
 else
     error('Function undefined for class %s of input (%s).',class(expr),name);

--- a/+casos/+package/+functions/FunctionArgumentType.m
+++ b/+casos/+package/+functions/FunctionArgumentType.m
@@ -6,10 +6,18 @@ classdef FunctionArgumentType
     end
 
     enumeration
+        % vectors & matrices
         DM ('casadi.DM')
         SX ('casadi.SX')
         MX ('casadi.MX') 
+
+        % polynomials
+        PD ('casos.PD')
         PS ('casos.PS')
+
+        % operators
+        PDOperator ('casos.PDOperator')
+        PSOperator ('casos.PSOperator')
     end
 
     methods

--- a/+casos/+package/+functions/FunctionInternal.m
+++ b/+casos/+package/+functions/FunctionInternal.m
@@ -67,6 +67,11 @@ methods
         s = struct;
     end
 
+    function J = jacobian(obj) %#ok<STOUT>
+        % Return Jacobian function if supported.
+        error('Derivatives cannot be calculated for %s.',obj.name)
+    end
+
     %% Call internal
     function argout = call(obj,argin)
         % Call function.

--- a/+casos/+package/+functions/PSFunction.m
+++ b/+casos/+package/+functions/PSFunction.m
@@ -84,6 +84,12 @@ end
 function [coeffs,z] = parse_expr(p)
 % Return coefficients, monomials, and size of polynomial expression.
 
-    p = casos.PS(p);
-    [coeffs,z] = poly2basis(p);
+    if isa(p,'casos.package.core.AbstractOperator')
+        op = casos.PSOperator(p);
+        [coeffs,z] = op2basis(op);
+
+    else
+        p = casos.PS(p);
+        [coeffs,z] = poly2basis(p);
+    end
 end

--- a/+casos/+package/operator.m
+++ b/+casos/+package/operator.m
@@ -1,18 +1,32 @@
 function op = operator(a,varargin)
 % Convert algebraic input to linear operator.
 
+if isa(a,'casos.package.core.OperatorSparsity')
+    % first input is operator sparsity pattern
+    assert(nargin > 1,'Not enough input arguments.')
+    assert(nargin < 3,'Too many input arguments.')
+
+    S = {a};
+    a = varargin{1};
+    varargin = {};
+
+else
+    % single input
+    S = {};
+end
+
 % choose suitable operator type
 switch class(a)
     case {'double' 'casadi.DM'}
-        % double polynomial
-        op = casos.PDOperator(a,varargin{:});
+        % double polynomial operator
+        op = casos.PDOperator(S{:},a,varargin{:});
 
     case 'casadi.SX'
-        % symbolic polynomial
-        op = casos.PSOperator(a,varargin{:});
+        % symbolic polynomial operator
+        op = casos.PSOperator(S{:},a,varargin{:});
 
     case 'casadi.MX'
-        % symbolic matrix polynomial
+        % symbolic matrix polynomial operator
         error('Not supported.')
 
     otherwise

--- a/+casos/+package/polynomial.m
+++ b/+casos/+package/polynomial.m
@@ -13,6 +13,11 @@ elseif isa(a,'casos.Indeterminates')
     p = casos.PD(a);
     return
 
+elseif isa(a,'casos.package.core.OperatorSparsity')
+    % first input is operator sparsity pattern
+    p = casos.package.operator(a,varargin{:});
+    return
+
 elseif isa(a,'casos.Sparsity')
     % first input is sparsity pattern
     assert(nargin > 1,'Not enough input arguments.')

--- a/+casos/Function.m
+++ b/+casos/Function.m
@@ -37,7 +37,7 @@ methods
             % fall back to casadi Function class
             wrap = CasadiFunction(name,ex_i,ex_o,name_i,name_o,varargin{:});
 
-        elseif any(types == 'PS') && ~any(types == 'MX')
+        elseif ~any(types == 'MX')
             % function between polynomials with symbolic coefficients
             wrap = PSFunction(name,ex_i,ex_o,name_i,name_o,varargin{:});
 


### PR DESCRIPTION
This PR improves the compatibility of linear operators and polynomial functions as follows:

1. Functions can now be defined between polynomial arguments and linear operators, e.g.,
  ```
  p = casos.PS.sym('p',monomials(casos.Indeterminates,0:2));
  q = ... % some polynomial expression
  J = casos.Function('J',{p},{jacobian(q,p)});
  ```

2. CasADi-style Jacobian functions can be computed for explicitly defined polynomial functions; where the Jacobian function of `f` is a mapping from the inputs of `f` *and* the outputs of `f` (typically unused) to the Jacobian (i.e., a linear operator) of the outputs of `f` with respect to the inputs of `f`, evaluated at the new inputs of the Jacobian function. For example, the code above is similar to
  ```
  f = casos.Function('f',{p},{q});
  J = jacobian(f);
  ```