### PR TITLE
Update ordering of indeterminate variables

### DIFF
--- a/+casos/+package/+core/@Polynomial/Polynomial.m
+++ b/+casos/+package/+core/@Polynomial/Polynomial.m
@@ -53,7 +53,7 @@ methods
 
         elseif ischar(varargin{1}) || isa(varargin{1},'casos.Indeterminates')
             % indeterminate (pvar / mpvar syntax)
-            [vars,I] = sort(casos.Indeterminates(varargin{:}));
+            [vars,~,I] = sort(casos.Indeterminates(varargin{:}));
             psparsity = to_vector(casos.Sparsity(vars),I,isrow(vars));
             coeffs = obj.new_coeff(coeff_sparsity(psparsity),1);
 

--- a/+casos/@Indeterminates/Indeterminates.m
+++ b/+casos/@Indeterminates/Indeterminates.m
@@ -140,7 +140,7 @@ end
 methods (Access={?casos.package.core.PolynomialInterface})
     % friend class access
     [indets,ic] = combine(varargin);
-    [indets,ic] = sort(obj);
+    [indets,ia,ic] = sort(obj);
 end
 
 end

--- a/+casos/@Indeterminates/Indeterminates.m
+++ b/+casos/@Indeterminates/Indeterminates.m
@@ -46,8 +46,9 @@ methods
 
         elseif length(arg) <= 2
             % syntax Indeterminates('x',m,n)
-            N = numel(zeros(arg{:},1));
-            obj.variables = compose('%s_%d',var,1:N);
+            N = numel(zeros(arg{:},1));     % number of variables
+            l = floor(log10(N))+1;          % number of places
+            obj.variables = compose(['%s_%0' num2str(l) 'd'],var,1:N);
 
         else
             error('Undefined syntax.')

--- a/+casos/@Indeterminates/sort.m
+++ b/+casos/@Indeterminates/sort.m
@@ -1,7 +1,7 @@
-function [out,I] = sort(obj)
+function [out,ia,ic] = sort(obj)
 % Sort indeterminate variables alphabetically.
 
-[vars,I] = sort(obj.variables);
+[vars,ia,ic] = unique(obj.variables);   % variables are already unique
 
 % return
 out = casos.Indeterminates;


### PR DESCRIPTION
This PR changes the naming and ordering of indeterminate variables in `PD` / `PS` vectors of indeterminates as reported by Issue #87. 

In particular, the syntax

```
casos.Indeterminates('x',N)
casos.PD('x',N)
casos.PS('x',N)
```

creates scalar variables `'x_0k'` for all `0 < k < 10` if `N ≥ 10` to ensure that the internal, alpha-numerical sorting results in an ascending order.