### PR TITLE
Print nonregular coefficients

### DIFF
--- a/+casos/+package/+core/@Polynomial/str.m
+++ b/+casos/+package/+core/@Polynomial/str.m
@@ -33,7 +33,7 @@ for ic = coeff_find(S)
 
     % string representation of coefficient and sign
     mdf = '';
-    if is_symbolic(cf)
+    if is_symbolic(cf) || ~is_regular(cf)
         % symbolic coefficient
         scf = sprintf('(%s)', str(cf));
         sgn = ' + ';


### PR DESCRIPTION
This PR changes the display output of polynomials to include nonregular coefficients (`inf`, `nan`), in partial correction to Issue #84.