### PR TITLE
Print non-regular coefficients (correction)

### DIFF
--- a/+casos/+package/+core/@Polynomial/str.m
+++ b/+casos/+package/+core/@Polynomial/str.m
@@ -33,8 +33,8 @@ for ic = coeff_find(S)
 
     % string representation of coefficient and sign
     mdf = '';
-    if is_symbolic(cf) || ~is_regular(cf)
-        % symbolic coefficient
+    if is_symbolic(cf) || (is_constant(cf) && ~is_regular(cf))
+        % symbolic or nonregular coefficient
         scf = sprintf('(%s)', str(cf));
         sgn = ' + ';
     elseif ~is_constant(cf)


### PR DESCRIPTION
This PR corrects a mistake in #90 which leads to an error when a symbolic polynomial expression (i.e., a polynomial of which some coefficients are symbolic expressions) is displayed.