### PR TITLE
Bug-fix: Coefficient dimension mismatch for substituting sparsity patterns

### DIFF
--- a/+casos/@Sparsity/coeff_subs.m
+++ b/+casos/@Sparsity/coeff_subs.m
@@ -35,8 +35,9 @@ degA = S1.degmat(:,~tf);
 
 if is_zerodegree(S2)
     % substitution with scalar expression
+    coeffb = repmat(coeffb,S1.numel,1);
     % coefficients of c = sum_a c_a*b^a1*y^a2
-    coeffs = coeff1.*T(coeffb);
+    coeffs = times_coeffs(coeff1, T(coeffb));
     % degree matrix of c 
     degmat = degA;
 


### PR DESCRIPTION
This PR fixes a dimension mismatch error when substituting with a zero-degree sparsity pattern. The error currently occurs because CasADi's `Sparsity` class requires patterns to be of the same size for intersection/element-wise multiplication.