### PR TITLE
Always evaluate functions on basis

### DIFF
--- a/+casos/+package/+functions/@FunctionWrapper/FunctionWrapper.m
+++ b/+casos/+package/+functions/@FunctionWrapper/FunctionWrapper.m
@@ -267,15 +267,4 @@ methods (Access=protected)
     end
 end
 
-methods (Access={?casos.package.functions.FunctionInternal})
-    %% Friend interface
-    function f = substitute(obj,varargin)
-        % Substitute variables.
-        assert(~is_null(obj), 'Notify the developers.')
-
-        f = obj;
-        f.wrap = substitute(obj.wrap,varargin{:});
-    end
-end
-
 end

--- a/+casos/+package/+functions/@FunctionWrapper/FunctionWrapper.m
+++ b/+casos/+package/+functions/@FunctionWrapper/FunctionWrapper.m
@@ -178,14 +178,14 @@ methods
         J = jacobian(obj.wrap);
     end
 
-    function out = call(obj,args)
+    function out = call(obj,args,varargin)
         % Evaluate function for given arguments.
         assert(~is_null(obj), 'Notify the developers.')
 
         if iscell(args)
             assert(length(args) == obj.n_in, 'Incorrect number of inputs: Expected %d, got %d.', obj.n_in, length(args));
 
-            out = call(obj.wrap,args);
+            out = call(obj.wrap,args,varargin{:});
             return
         end
 
@@ -210,7 +210,7 @@ methods
         argin(idx_in+1) = struct2cell(args);
         
         % call function with cell
-        argout = call(obj.wrap,argin);
+        argout = call(obj.wrap,argin,varargin{:});
 
         % name of outputs
         fn_out = arrayfun(@(i) obj.name_out(i), 0:obj.n_out-1, 'UniformOutput', false);

--- a/+casos/+package/+functions/CasadiFunction.m
+++ b/+casos/+package/+functions/CasadiFunction.m
@@ -9,10 +9,6 @@ properties (Dependent,SetAccess=private)
     class_name;
 end
 
-properties (Constant,Access=protected)
-    allow_eval_on_basis = false;
-end
-
 methods
     function obj = CasadiFunction(name, ex_i, ex_o, name_i, name_o, varargin)
         % Create new casadi function object.
@@ -81,9 +77,14 @@ methods
         i = index_out(obj.func,str);
     end
 
-    function argout = call(obj, argin)
+    function argout = call(obj, argin, on_basis)
         % Evaluate casadi function object.
         argout = call(obj.func, argin);
+
+        if nargin > 2 && on_basis
+            % return nonzero entries only
+            argout = cellfun(@(c,i) sparsity_cast(c,casadi.Sparsity.dense(nnz_out(obj.func,i),1)), argout(:), num2cell((1:get_n_out(obj))'-1), 'UniformOutput', false);
+        end
     end
 
     function s = get_stats(obj)

--- a/+casos/+package/+functions/FunctionCommon.m
+++ b/+casos/+package/+functions/FunctionCommon.m
@@ -49,9 +49,4 @@ methods
     end
 end
 
-methods (Abstract, Access={?casos.package.functions.FunctionCommon, ?casos.package.functions.FunctionWrapper})
-    %% Friend interface
-    f = substitute(obj,varargin);
-end
-
 end

--- a/+casos/+package/+functions/FunctionInternal.m
+++ b/+casos/+package/+functions/FunctionInternal.m
@@ -9,10 +9,6 @@ properties (SetAccess = private)
     name;
 end
 
-properties (Abstract,Constant,Access=protected)
-    allow_eval_on_basis;
-end
-
 methods (Abstract)
     % inputs
     n = get_n_in(obj);
@@ -73,12 +69,12 @@ methods
     end
 
     %% Call internal
-    function argout = call(obj,argin)
+    function argout = call(obj,argin,on_basis)
         % Call function.
-        if ~obj.allow_eval_on_basis
-            % evaluate function on polynomials
-            argout = eval(obj,argin); %#ok<EV2IN>
-        
+        if nargin > 2 && on_basis
+            % evaluate on coordinates
+            argout = eval_on_basis(obj,argin);
+
         else
             % get nonzero coordinates for basis
             in = cellfun(@(p,i) poly2basis(p,get_sparsity_in(obj,i)), argin(:), num2cell((1:get_n_in(obj))'-1), 'UniformOutput', false);
@@ -92,11 +88,6 @@ end
 
 methods (Access=protected)
     %% Internal evaluation
-    function argout = eval(obj,argin) %#ok<STOUT,INUSD>
-        % Evaluate function on polynomials.
-        error('Not implemented.')
-    end
-
     function argout = eval_on_basis(obj,argin) %#ok<STOUT,INUSD>
         % Evaluate function on nonzero polynomials.
         error('Not implemented.')

--- a/+casos/+package/+functions/FunctionInternal.m
+++ b/+casos/+package/+functions/FunctionInternal.m
@@ -94,12 +94,4 @@ methods (Access=protected)
     end
 end
 
-methods (Access={?casos.package.functions.FunctionCommon, ?casos.package.functions.FunctionWrapper})
-    %% Friend interface
-    function substitute(obj,varargin)
-        % Substitute variables.
-        error('Method SUBSTITUTE not supported for %s.',obj.class_name)
-    end
-end
-
 end

--- a/+casos/+package/+functions/PSFunction.m
+++ b/+casos/+package/+functions/PSFunction.m
@@ -12,10 +12,6 @@ properties (SetAccess=private)
     class_name = 'PSFunction';
 end
 
-properties (Constant,Access=protected)
-    allow_eval_on_basis = true;
-end
-
 methods
     function obj = PSFunction(arg1, ex_i, ex_o, name_i, name_o, varargin)
         % Create new casadi function object.

--- a/+casos/+package/+solvers/@QuasiconvBisection/QuasiconvBisection.m
+++ b/+casos/+package/+solvers/@QuasiconvBisection/QuasiconvBisection.m
@@ -22,8 +22,6 @@ properties (Constant,Access=protected)
          'tolerance_rel', 'Relative tolerance for stopping criterion.'
          'verbose', 'Turn on/off iteration display.'}
     ];
-
-    allow_eval_on_basis = true;
 end
 
 properties (SetAccess=private)

--- a/+casos/+package/+solvers/@SdpsolInternal/SdpsolInternal.m
+++ b/+casos/+package/+solvers/@SdpsolInternal/SdpsolInternal.m
@@ -127,29 +127,4 @@ methods (Access=protected)
     end
 end
 
-methods (Access={?casos.package.functions.FunctionCommon, ?casos.package.functions.FunctionWrapper})
-    function S = substitute(obj,idx,expr_in,expr_out)
-        % Substitute a variable for expr_in -> expr_out.
-        if ischar(idx)
-            % map variable name to index
-            idx = index_in(obj.fhan,idx);
-        end
-
-        % get current input symbols
-        var_in  = sx_in(obj.fhan);
-        var_out = var_in;
-        % replace variable
-        var_in{idx+1}  = expr_in; % CasADi uses 0-based index
-        var_out{idx+1} = expr_out;
-
-        % NOTE: As per Casadi v3.6.5, functions' input and output names 
-        % must be mutually exclusive unless explicity permitted.
-        fopt = struct('allow_duplicate_io_names',true);
-
-        % substitute
-        fhan_new = casadi.Function('f',var_in,call(obj.fhan,var_out),name_in(obj.fhan),name_out(obj.fhan),fopt);
-        S = casos.package.solvers.SdpsolInternal(obj,fhan_new);
-    end
-end
-
 end

--- a/+casos/+package/+solvers/@SossdpRelaxation/SossdpRelaxation.m
+++ b/+casos/+package/+solvers/@SossdpRelaxation/SossdpRelaxation.m
@@ -12,8 +12,6 @@ properties (Constant,Access=protected)
         {'sdpsol_options', 'Options to be passed to the SDP solver.';...
          'newton_solver', 'Solver used for the Newton simplification (defaults to the one used in sdpsol)'}
     ];
-
-    allow_eval_on_basis = true;
 end
 
 properties (SetAccess=private)

--- a/+casos/+package/+solvers/@SossdpRelaxation/SossdpRelaxation.m
+++ b/+casos/+package/+solvers/@SossdpRelaxation/SossdpRelaxation.m
@@ -81,27 +81,4 @@ methods
     end
 end
 
-methods (Access={?casos.package.functions.FunctionCommon, ?casos.package.functions.FunctionWrapper})
-    function S = substitute(obj,idx,expr_in,expr_out)
-        % Substitute a variable for expr_in -> expr_out.
-        if ischar(idx)
-            % map variable name to index
-            idx = get_index_in(obj,idx);
-        end
-
-        % only parameter subsitution supported
-        assert(idx == 1,'Subsitution of input %d not allowed.',idx)
-
-        % project to basis
-        [Qin,Zin] = poly2basis(expr_in);
-        Qout = poly2basis(expr_out,obj.sparsity_p);
-
-        % substitute
-        S = copy(obj);
-        S.sdpsolver = substitute(obj.sdpsolver,idx,Qin,Qout);
-        % store new basis
-        S.sparsity_p = Zin;
-    end
-end
-
 end

--- a/+casos/+package/+solvers/SolverCallback.m
+++ b/+casos/+package/+solvers/SolverCallback.m
@@ -70,12 +70,4 @@ methods
     end
 end
 
-methods (Access={?casos.package.functions.FunctionCommon, ?casos.package.functions.FunctionWrapper})
-    %% Friend interface
-    function substitute(obj,varargin)
-        % Substitute variables.
-        error('Method SUBSTITUTE not supported for %s.',obj.class_name)
-    end
-end
-
 end

--- a/+casos/+package/+solvers/SosoptCommon.m
+++ b/+casos/+package/+solvers/SosoptCommon.m
@@ -155,12 +155,12 @@ methods
         idx = ii - 1;
     end
 
-    function argout = call(obj,argin)
+    function argout = call(obj,argin,on_basis)
         % Call function (override for efficiency).
         
-        if ~obj.allow_eval_on_basis
-            % evaluate on polynomials
-            argout = eval(obj,argin); %#ok<EV2IN>
+        if nargin > 2 && on_basis
+            % evaluate on basis
+            argout = eval_on_basis(obj,argin);
             return
         end
 
@@ -184,7 +184,6 @@ methods
         argout{3} = casos.package.polynomial(obj.sparsity_g,out{3});
         argout{4} = casos.package.polynomial(obj.sparsity_x,out{4});
         argout{5} = casos.package.polynomial(obj.sparsity_g,out{5});
-        
     end
 end
 


### PR DESCRIPTION
This PR makes `eval_on_basis` the default for function evaluation. Also, the `substitute` method is removed since it is unused.