### PR TITLE
Concatenation of multiple sparsity patterns

### DIFF
--- a/+casos/@Sparsity/cat.m
+++ b/+casos/@Sparsity/cat.m
@@ -5,7 +5,7 @@ function S = cat(dim,varargin)
 
 if nargin ~= 3
     % handle non-binary concatenation
-    p = cat@casos.package.core.PolynomialInterface(dim,varargin{:});
+    S = cat@casos.package.core.PolynomialInterface(dim,varargin{:});
     return
 end
 


### PR DESCRIPTION
There is an error if more (or less) than two sparsity patterns are concatenated,

> Output argument "S" (and possibly others) not assigned a value in the execution with "casos.Sparsity/cat" function.

This is fixed now.