### PR TITLE
BREAKING: Check for constant expressions.

### DIFF
--- a/+casos/+package/+core/@Polynomial/Polynomial.m
+++ b/+casos/+package/+core/@Polynomial/Polynomial.m
@@ -73,11 +73,6 @@ methods
         tf = is_symbolic(obj.coeffs(coeff_find(obj.get_sparsity)));
     end
 
-    function tf = is_symexpr(obj)
-        % Check if polynomial contains symbolic expressions.
-        tf = ~is_constant(obj.coeffs);
-    end
-
     function tf = is_zero(obj)
         % Check if polynomial is equal to zero.
         tf = (is_zerodegree(obj) && is_zero(obj.coeffs));
@@ -90,7 +85,7 @@ methods
 
     function tf = is_constant(obj)
         % Check if polynomial is constant.
-        tf = (is_zerodegree(obj) && ~is_symexpr(obj));
+        tf = is_constant(obj.coeffs);
     end
 
     function [tf,I] = is_monom(obj)

--- a/+casos/+package/+core/GenericPolynomial.m
+++ b/+casos/+package/+core/GenericPolynomial.m
@@ -13,6 +13,11 @@ properties (Dependent)
     mindeg;
 end
 
+methods (Abstract)
+    %% Abstract interface
+    tf = is_constant(obj);
+end
+
 methods
     %% Getter
     function n = get.nvars(obj)
@@ -88,6 +93,11 @@ methods
     function tf = is_homogeneous(obj,varargin)
         % Check if polynomial is homogeneous.
         tf = is_homogeneous(obj.poly_sparsity,varargin{:});
+    end
+
+    function tf = is_constant_poly(obj)
+        % Check if polynomial is a constant value.
+        tf = (is_constant(obj) && is_zerodegree(obj));
     end
 
     function tf = is_dense(obj)

--- a/+casos/+toolboxes/+sosopt/pvolume.m
+++ b/+casos/+toolboxes/+sosopt/pvolume.m
@@ -51,7 +51,7 @@ end
 if isempty(v)
     v = 1;
 elseif ~isa(v, 'double') 
-    assert(v.is_constant, 'Level set value must be a constant');
+    assert(is_constant_poly(v), 'Level set value must be a constant');
     v = full(casos.PD(v));
 end
 
@@ -75,7 +75,7 @@ else
     assert(is_indet(var), 'First column of the domain must be a vector of indeterminate variables.');
 
     % Check if the domain does not contain symbolic variables
-    assert(bounds.is_constant, 'Domain must not contain symbolic variables.');
+    assert(is_constant_poly(bounds), 'Domain must not contain symbolic variables.');
 
     % Convert bounds to PD followed by conversion to double via full
     bounds = full(casos.PD(bounds));

--- a/+casos/+toolboxes/to_multipoly.m
+++ b/+casos/+toolboxes/to_multipoly.m
@@ -1,7 +1,7 @@
 function q = to_multipoly(p)
 % Convert a polynomial with constant coefficients into a multipoly object.
 
-assert(~is_symexpr(p), 'Cannot convert polynomials with symbolic coefficients.')
+assert(is_constant(p), 'Cannot convert polynomials with symbolic coefficients.')
 
 p = casos.PD(p);
 

--- a/+casos/PS.m
+++ b/+casos/PS.m
@@ -97,7 +97,7 @@ methods
 
     function p = casos.PD(obj)
         % Convert to double polynomial.
-        assert(~is_symexpr(obj), 'Cannot convert symbolic polynomials.')
+        assert(is_constant(obj), 'Cannot convert symbolic polynomials.')
 
         p = casos.PD(obj.get_sparsity);
         p.coeffs = casadi.DM(obj.coeffs);


### PR DESCRIPTION
The function `is_constant` now checks only whether polynomials (or their coefficients) are constant expressions. The old behaviour, which also took into account the degree of the polynomial, is now given by `is_constant_poly`. 

So we have

- `is_constant` returns true if and only if all coefficients are constant.
- `is_constant_poly` returns true if and only if all coefficients are constant *and* the polynomial is of degree zero.

The function `is_symexpr` is obsolete and thus removed. Use `~is_constant` instead.