### PR TITLE
fix(pvolume): ensure xmin/xmax are column vectors

### DIFF
--- a/+casos/+toolboxes/+sosopt/pvolume.m
+++ b/+casos/+toolboxes/+sosopt/pvolume.m
@@ -63,8 +63,8 @@ end
 if isempty(domain)
     % Default domain: [-1, 1] for each variable
     nvar = p.nvars;
-    xmin = -ones(1,nvar);
-    xmax = ones(1,nvar);
+    xmin = -ones(nvar,1);
+    xmax = ones(nvar,1);
 else
     % Extract variables and bounds from the domain
     nvar = size(domain,1); 


### PR DESCRIPTION
Previously `xmin` and `xmax` were initialized as `1×nvar` row vectors when no domain was provided, which caused dimension mismatches during sampling when combined with `rand(nvar, npts)`. They are now created as `nvar×1` column vectors to align with expected shapes.