### PR TITLE
Permute Hessian matrix to facilitate Cholesky decomposition

### DIFF
--- a/+casos/+package/+solvers/@ConicSolver/ConicSolver.m
+++ b/+casos/+package/+solvers/@ConicSolver/ConicSolver.m
@@ -29,7 +29,9 @@ properties (Access=protected)
 end
 
 properties (Constant, Access=protected)
-    conic_options = casos.package.solvers.SolverCallback.solver_options;
+    conic_options = [casos.package.solvers.SolverCallback.solver_options
+        {'hessian_permute', 'Inverse permutation matrix for the Hessian.'}
+    ];
 
     conic_cones = casos.package.Cones([
         casos.package.Cones.LIN
@@ -78,6 +80,7 @@ methods
         % default options
         if ~isfield(obj.opts,'Kx'), obj.opts.Kx = struct('lin',n); end
         if ~isfield(obj.opts,'Kc'), obj.opts.Kc = struct('lin',m); end
+        if ~isfield(obj.opts,'hessian_permute'), obj.opts.hessian_permute = 1; end
 
         % check cone dimensions
         assert(obj.getnumc(obj.opts.Kx) == n, 'Dimension of Kx must equal to number of variables (%d).', n)

--- a/+casos/+package/+solvers/@MosekInterface/MosekInterface.m
+++ b/+casos/+package/+solvers/@MosekInterface/MosekInterface.m
@@ -15,7 +15,6 @@ end
 properties (Constant, Access=protected)
     mosek_options = [casos.package.solvers.ConicSolver.conic_options
         {'mosek_param', 'Parameters to be passed to MOSEK.'
-         'cholesky_method','Parameter that defines how cholseky is computed (symbollically or numerically online) '
          'mosek_echo',  'Verbosity level passed to MOSEK (default: 0).'}
     ];
 end

--- a/+casos/+package/+solvers/@MosekInterface/MosekInterface.m
+++ b/+casos/+package/+solvers/@MosekInterface/MosekInterface.m
@@ -10,6 +10,8 @@ end
 
 properties (Access=private)
     info = struct;
+
+    fhan_pre;   % precomputation (numerical Hessian workaround)
 end
 
 properties (Constant, Access=protected)

--- a/+casos/+package/+solvers/@MosekInterface/buildproblem.m
+++ b/+casos/+package/+solvers/@MosekInterface/buildproblem.m
@@ -166,9 +166,13 @@ prob.bux = [ubx; +inf(Nx_q,1)];
 % arguments to problem
 args_in = obj.args_in;
 
+% options for Casadi functions
+% NOTE: As per Casadi v3.6.5, functions' input and output names 
+% must be mutually exclusive unless explicity permitted.
+fopt = struct('allow_duplicate_io_names',true);
+
 % handle quadratic cost function
 % MOSEK cannot solve conic problems with quadratic cost
-
 if nnz(h) > 0
     % inverse permutation matrix for Cholesky decomposition
     Pinv = obj.opts.hessian_permute;
@@ -176,11 +180,9 @@ if nnz(h) > 0
 
     % permute Hessian
     hPerm = P'*h*P;
-    
-    % only SX supports Cholesky decomposition
-    H = casadi.SX.sym('H',sparsity(hPerm));
-    % performs a Cholesky decomposition R'*R = (P'*H*P)
-    chol_f = casadi.Function('chol',{H},{chol(H)});
+
+    % number of variables after permutation
+    nP = length(hPerm);
 
     % rewrite quadratic cost
     %
@@ -191,10 +193,37 @@ if nnz(h) > 0
     %   min_{x,y} c'*x + y, s.t. 1 + y >= ||(sqrt(2)*U*x, 1 - y)||
     %
     % with additional variable y and Cholesky decomposition U'*U = Q
-    U = chol_f(hPerm);
-    
-    % number of variables after permutation
-    nP = length(U);
+
+    %NOTE: symbolic Cholesky decomposition via SX is temporarily disabled
+    if (false)
+        % only SX supports Cholesky decomposition
+        H = casadi.SX.sym('H',sparsity(hPerm)); %#ok<UNRCH>
+        % performs a Cholesky decomposition R'*R = (P'*H*P)
+        chol_f = casadi.Function('chol',{H},{chol(H)});
+        % apply Cholesky decomposition symbolically
+        U = chol_f(hPerm);
+
+    else
+        % workaround to compute Cholesky decomposition online
+        [rows,~] = get_triplet(sparsity(hPerm));
+        % identify nonzero blocks of (permuted) Hessian
+        min_row = min(rows);
+        max_row = max(rows);
+        % upper triangular sparsity pattern
+        spU = casadi.Sparsity.upper(max_row - min_row + 1);
+        % enlarge to size of (permuted) Hessian
+        spU.enlarge(nP, nP, min_row:max_row, min_row:max_row);
+        
+        % symbolic variable for Cholesky decomposition
+        U = casadi.MX.sym('U',spU);
+
+        % evaluate decomposition online
+        args_pre = setfield(args_in,'h',hPerm); %#ok<SFLD>
+        % return permuted Hessian for decomposition
+        obj.fhan_pre = casadi.Function('f_pre',struct2cell(args_in),struct2cell(args_pre),fieldnames(args_in),fieldnames(args_pre),fopt);
+        % use symbolic variable in lieu of Hessian
+        args_in.h = U;
+    end
 
     % build affine cone constraint 
     % L(y,x) + k = (1+y, sqrt(2)*U/P*x, 1-y) in SOC
@@ -233,10 +262,6 @@ else
     acc_cost = [];
 end
 
-% options for Casadi functions
-% NOTE: As per Casadi v3.6.5, functions' input and output names 
-% must be mutually exclusive unless explicity permitted.
-fopt = struct('allow_duplicate_io_names',true);
 % return MOSEK prob structure
 obj.fhan = casadi.Function('f',struct2cell(args_in),struct2cell(prob),fieldnames(args_in),fieldnames(prob),fopt);
 % return bar values
@@ -274,7 +299,7 @@ sol.bars = casadi.MX.sym('bars',[sum(Nx_S) 1]);
 [~,Slx,~] = separate(sol.slx,[Nx_cost Nx.l Nx_q],1);
 [~,Slu,~] = separate(sol.sux,[Nx_cost Nx.l Nx_q],1);
 % dual variables corresponding to affine conic constraints
-[Yaq,Yas,Yxq,Ycost] = separate(sol.doty,[Na_q sum(Na_S) Nx_q Na_cost],1);
+[Yaq,Yas,Yxq,Ycost] = separate(sol.doty,[Na_q sum(Na_S) Nx_q Na_cost],1); %#ok<ASGLU>
 % de-vectorize SDP primal and dual variables (no scaling)
 Xc_s = obj.sdp_mat(sol.barx,Nx.s,1) + cbx_s;
 Sc_s = obj.sdp_mat(sol.bars,Nx.s,1);

--- a/+casos/+package/+solvers/@MosekInterface/eval.m
+++ b/+casos/+package/+solvers/@MosekInterface/eval.m
@@ -7,7 +7,9 @@ args = cell2struct(argin',fieldnames(obj.args_in));
 
 % compute cholseky numerically
 if nnz(obj.args_in.h) > 0 && strcmp(obj.opts.cholesky_method,'numerical')
-    args.h = chol((args.h));
+    Pinv = obj.opts.hessian_permute;
+    P = Pinv'/(Pinv*Pinv');
+    args.h = chol(P'*args.h*P);
 end
 
 

--- a/+casos/+package/+solvers/@MosekInterface/eval.m
+++ b/+casos/+package/+solvers/@MosekInterface/eval.m
@@ -5,14 +5,6 @@ msk_prob = obj.cone;
 
 args = cell2struct(argin',fieldnames(obj.args_in));
 
-% compute cholseky numerically
-if nnz(obj.args_in.h) > 0 && strcmp(obj.opts.cholesky_method,'numerical')
-    Pinv = obj.opts.hessian_permute;
-    P = Pinv'/(Pinv*Pinv');
-    args.h = chol(P'*args.h*P);
-end
-
-
 % evaluate problem structure
 prob = call(obj.fhan,args);
 data = call(obj.barv,args);

--- a/+casos/+package/+solvers/@MosekInterface/eval.m
+++ b/+casos/+package/+solvers/@MosekInterface/eval.m
@@ -5,6 +5,14 @@ msk_prob = obj.cone;
 
 args = cell2struct(argin',fieldnames(obj.args_in));
 
+%NOTE: we always compute Cholesky numerically for now
+if nnz(obj.args_in.h) > 0 % && strcmp(obj.opts.cholesky_method,'numerical')
+    % arguments for precomputation
+    args = call(obj.fhan_pre,args);
+    % compute Cholesky decomposition of Hessian
+    args.h = chol(args.h);
+end
+
 % evaluate problem structure
 prob = call(obj.fhan,args);
 data = call(obj.barv,args);
@@ -28,7 +36,7 @@ msk_prob.barf.val = full(data.f);
 
 msk_param = obj.opts.mosek_param;
 msk_param.MSK_IPAR_AUTO_UPDATE_SOL_INFO = 'MSK_ON';
-msk_param.MSK_IPAR_INTPNT_BASIS         ='MSK_BI_NEVER';
+msk_param.MSK_IPAR_INTPNT_BASIS         = 'MSK_BI_NEVER';
 % msk_param.MSK_IPAR_INTPNT_STARTING_POINT = 'MSK_STARTING_POINT_CONSTANT';
 msk_echo  = obj.opts.mosek_echo;
     

--- a/+casos/+package/+solvers/@SdpsolInternal/SdpsolInternal.m
+++ b/+casos/+package/+solvers/@SdpsolInternal/SdpsolInternal.m
@@ -139,8 +139,14 @@ methods
         else
             p = [];
         end
+
         % constraint function (vectorized)
         sdp_g = sdp.g(:);
+
+        if isfield(opts,'hessian_permute')
+            % map Hessian permutation matrix to extended variable space
+            opts.hessian_permute = opts.hessian_permute*primal_x_map;
+        end
 
         % use pre-computed derivatives (undocumented)
         if isfield(sdp,'derivatives')

--- a/+casos/+package/+solvers/@SossdpRelaxation/buildproblem.m
+++ b/+casos/+package/+solvers/@SossdpRelaxation/buildproblem.m
@@ -98,6 +98,7 @@ sdp.x = [Qvar_sdp; Qcon_G];
 sdp.f = sdp_f;
 sdp.g = sdp_g - map_g*Qcon_G;
 sdp.p = Qpar;
+
 % store derivatives
 sdp.derivatives.Hf = blockcat(map_x'*sdp_Hf*map_x, ...
                               sparse(nnz_lin_x+nnz_gram_x,nnz_gram_g), ...
@@ -109,6 +110,9 @@ sdp.derivatives.Jg = horzcat(sdp_Jg*map_x, -map_g);
 sdpopt = opts.sdpsol_options;
 sdpopt.Kx = struct('lin', nnz_lin_x, 'psd', [Ksdp_x_s; Ksdp_g_s]);
 sdpopt.Kc = struct('lin', nnz_lin_g + nnz_sos_g);
+
+% inverse permutation of Hessian for Cholesky decomposition
+sdpopt.hessian_permute = [map_x sparse(nnz_lin_x+nnz_sos_x,nnz_gram_g)];
 
 % initialize SDP solver
 obj.sdpsolver = casos.package.solvers.SdpsolInternal('SDP',solver,sdp,sdpopt);

--- a/+casos/+package/+solvers/@SossdpRelaxation/buildproblem.m
+++ b/+casos/+package/+solvers/@SossdpRelaxation/buildproblem.m
@@ -75,7 +75,7 @@ Qvar_sdp = [Qvar_l; Qvar_G];
 
 if (Nds + Nsds + Mds + Msds) > 0
     % create reordering map (for DSOS/SDSOS)
-    permute_x = process_reorder(Qvar_G,Qcon_G,Ksdp_x_s,Ksdp_g_s,Qvar_l,Ns,Ms,Nds,Mds);
+    permute_x = process_reorder(Qvar_G,Qcon_G,Ksdp_x_s,Ksdp_g_s,Qvar_l,Ns,Ms,Nds,Mds)';
 else
     permute_x = speye(nnz_sdp_x + nnz_gram_g);
 end
@@ -117,18 +117,15 @@ Qvar_mapped = map_x*Qvar_sdp;
 map_g = blkdiag(sparse(nnz_lin_g,0), Mp_g);
 
 % build SDP problem
-sdp.x = permute_x*[Qvar_sdp; Qcon_G];
+sdp.x = permute_x'*[Qvar_sdp; Qcon_G];
 sdp.f = sdp_f;
 sdp.g = sdp_g - map_g*Qcon_G;
 sdp.p = Qpar;
 
-% transpose of permutation matrix
-permMat_t = permute_x';
-
 % store derivatives
-sdp.derivatives.Hf = permMat_t(1:nnz_sdp_x,:)'*map_x'*sdp_Hf*map_x*permMat_t(1:(nnz_sdp_x),:);
-sdp.derivatives.Jf = sdp_Jf*map_x*permMat_t(1:nnz_sdp_x,:);
-sdp.derivatives.Jg = sdp_Jg*map_x*permMat_t(1:nnz_sdp_x,:)-map_g*permMat_t(nnz_sdp_x+1:end,:);
+sdp.derivatives.Hf = permute_x(1:nnz_sdp_x,:)'*map_x'*sdp_Hf*map_x*permute_x(1:(nnz_sdp_x),:);
+sdp.derivatives.Jf = sdp_Jf*map_x*permute_x(1:nnz_sdp_x,:);
+sdp.derivatives.Jg = sdp_Jg*map_x*permute_x(1:nnz_sdp_x,:)-map_g*permute_x(nnz_sdp_x+1:end,:);
 
 % SDP options
 sdpopt = opts.sdpsol_options;
@@ -158,7 +155,7 @@ end
 sdpopt.Kc = struct('lin', nnz_lin_g + nnz_sos_g);
 
 % inverse permutation of Hessian for Cholesky decomposition
-sdpopt.hessian_permute = map_x*permMat_t(1:(nnz_sdp_x),:);
+sdpopt.hessian_permute = map_x*permute_x(1:(nnz_sdp_x),:);
 
 % initialize SDP solver
 obj.sdpsolver = casos.package.solvers.SdpsolInternal('SDP',solver,sdp,sdpopt);
@@ -183,16 +180,16 @@ sdpsol.lam_g = casadi.SX.sym('sol_lam_g',size(sdp.g));
 sdpsol.lam_p = casadi.SX.sym('sol_lam_p',size(sdp.p));
 
 % % coordinates of SOS solution
-sossol.x = blkdiag(speye(nnz_lin_x), Mp_x, sparse(0,nnz_gram_g))*permute_x'*sdpsol.x;
+sossol.x = blkdiag(speye(nnz_lin_x), Mp_x, sparse(0,nnz_gram_g))*permute_x*sdpsol.x;
 sossol.f = sdpsol.f;
 sossol.g = [
     blkdiag(speye(nnz_lin_g), sparse(0,nnz_sos_g))*sdpsol.g
-    blkdiag(sparse(0,nnz_lin_x+nnz_gram_x),  Mp_g)*permute_x'*sdpsol.x
+    blkdiag(sparse(0,nnz_lin_x+nnz_gram_x),  Mp_g)*permute_x*sdpsol.x
 ];
-sossol.lam_x = blkdiag(speye(nnz_lin_x), Md_x, sparse(0,nnz_gram_g))*permute_x'*sdpsol.lam_x;
+sossol.lam_x = blkdiag(speye(nnz_lin_x), Md_x, sparse(0,nnz_gram_g))*permute_x*sdpsol.lam_x;
 sossol.lam_g = [
     blkdiag(speye(nnz_lin_g), sparse(0,nnz_sos_g))*sdpsol.lam_g
-    blkdiag(sparse(0,nnz_lin_x+nnz_gram_x),  Md_g)*permute_x'*sdpsol.lam_x
+    blkdiag(sparse(0,nnz_lin_x+nnz_gram_x),  Md_g)*permute_x*sdpsol.lam_x
 ];
 
 % options for Casadi functions


### PR DESCRIPTION
In sum-of-squares optimization problems with quadratic cost function, the additional decision variables for the Gram decomposition imply that the Hessian matrix of the underlying semidefinite program that is not positive definite; this often leads to issues with the Cholesky decomposition. 

Higham (1990) has the following result:[^1]

> Lemma 1.1. Let $A$ be positive semi-definite, of rank $r$.
> (b) There is a permutation $\Pi$ such that $\Pi^\top A \Pi$ has a unique Cholesky decomposition [...]

[^1]: Higham, Nicholas J. (1990) Analysis of the Cholesky Decomposition of a Semi-definite Matrix. In: Reliable Numerical Computation. Oxford University Press, Oxford, UK, pp. 161-185. [(online)](https://eprints.maths.manchester.ac.uk/1193/)

This PR introduces an optional permutation matrix for conic solvers. Moreover, provided the original Hessian matrix in the sum-of-squares optimization problem was positive definite, a suitable permutation matrix is inferred from the mapping of the Gram decision variables to the polynomial decision variables, resulting in a smaller (permuted) Hessian in the underlying semidefinite program.

*Edit 29.05.2026:*

> [!NOTE]
> The option to _symbolically_ evaluate the Cholesky decomposition during Mosek's `buildproblem` method is deactivated until a better solution is found.