### PR TITLE
Bug-fix: correct handling of unknown status using Mosek

### DIFF
--- a/+casos/+package/+solvers/@MosekInterface/eval.m
+++ b/+casos/+package/+solvers/@MosekInterface/eval.m
@@ -123,19 +123,19 @@ if ~isempty(msk_sol)
                                                                                       abs(res.info.MSK_DINF_SOL_ITR_DUAL_OBJ)]));
             
             % log values for decision logic
-            obj.solver_info.acceptable_solution.primMaxVio  = primMaxVio;
-            obj.solver_info.acceptable_solution.dualMaxVio  = dualMaxVio;
-            obj.solver_info.acceptable_solution.relativeGap = relativeGap;
-            obj.solver_info.acceptable_solution.optMeas     = optMeas;
-            obj.solver_info.acceptable_solution.maxNorm     = maxNorm;
+            obj.solver_stats.acceptable_solution.primMaxVio  = primMaxVio;
+            obj.solver_stats.acceptable_solution.dualMaxVio  = dualMaxVio;
+            obj.solver_stats.acceptable_solution.relativeGap = relativeGap;
+            obj.solver_stats.acceptable_solution.optMeas     = optMeas;
+            obj.solver_stats.acceptable_solution.maxNorm     = maxNorm;
             
             % store the decision values thresholds
             % user can check what led to the decision
-            obj.solver_info.acceptable_solution.tolerances.primMaxVio  = feasibilityTol;
-            obj.solver_info.acceptable_solution.tolerances.dualMaxVio  = feasibilityTol;
-            obj.solver_info.acceptable_solution.tolerances.relativeGap = obj.opts.augmented_check.relativeGap;
-            obj.solver_info.acceptable_solution.tolerances.maxNorm     = obj.opts.augmented_check.maxNorm;
-            obj.solver_info.acceptable_solution.tolerances.optMeas     = obj.opts.augmented_check.optMeas;
+            obj.solver_stats.acceptable_solution.tolerances.primMaxVio  = feasibilityTol;
+            obj.solver_stats.acceptable_solution.tolerances.dualMaxVio  = feasibilityTol;
+            obj.solver_stats.acceptable_solution.tolerances.relativeGap = obj.opts.augmented_check.relativeGap;
+            obj.solver_stats.acceptable_solution.tolerances.maxNorm     = obj.opts.augmented_check.maxNorm;
+            obj.solver_stats.acceptable_solution.tolerances.optMeas     = obj.opts.augmented_check.optMeas;
             
             % decision logic for solution acceptability
             if (relativeGap < obj.opts.augmented_check.relativeGap) ...    % ensure relative gap is less than 5%

--- a/+casos/+package/+solvers/@MosekInterface/eval.m
+++ b/+casos/+package/+solvers/@MosekInterface/eval.m
@@ -123,19 +123,19 @@ if ~isempty(msk_sol)
                                                                                       abs(res.info.MSK_DINF_SOL_ITR_DUAL_OBJ)]));
             
             % log values for decision logic
-            obj.info.acceptable_solution.primMaxVio  = primMaxVio;
-            obj.info.acceptable_solution.dualMaxVio  = dualMaxVio;
-            obj.info.acceptable_solution.relativeGap = relativeGap;
-            obj.info.acceptable_solution.optMeas     = optMeas;
-            obj.info.acceptable_solution.maxNorm     = maxNorm;
+            obj.solver_info.acceptable_solution.primMaxVio  = primMaxVio;
+            obj.solver_info.acceptable_solution.dualMaxVio  = dualMaxVio;
+            obj.solver_info.acceptable_solution.relativeGap = relativeGap;
+            obj.solver_info.acceptable_solution.optMeas     = optMeas;
+            obj.solver_info.acceptable_solution.maxNorm     = maxNorm;
             
             % store the decision values thresholds
             % user can check what led to the decision
-            obj.info.acceptable_solution.tolerances.primMaxVio  = feasibilityTol;
-            obj.info.acceptable_solution.tolerances.dualMaxVio  = feasibilityTol;
-            obj.info.acceptable_solution.tolerances.relativeGap = obj.opts.augmented_check.relativeGap;
-            obj.info.acceptable_solution.tolerances.maxNorm     = obj.opts.augmented_check.maxNorm;
-            obj.info.acceptable_solution.tolerances.optMeas     = obj.opts.augmented_check.optMeas;
+            obj.solver_info.acceptable_solution.tolerances.primMaxVio  = feasibilityTol;
+            obj.solver_info.acceptable_solution.tolerances.dualMaxVio  = feasibilityTol;
+            obj.solver_info.acceptable_solution.tolerances.relativeGap = obj.opts.augmented_check.relativeGap;
+            obj.solver_info.acceptable_solution.tolerances.maxNorm     = obj.opts.augmented_check.maxNorm;
+            obj.solver_info.acceptable_solution.tolerances.optMeas     = obj.opts.augmented_check.optMeas;
             
             % decision logic for solution acceptability
             if (relativeGap < obj.opts.augmented_check.relativeGap) ...    % ensure relative gap is less than 5%


### PR DESCRIPTION
With 111f6211c94e70ba719b07b516d464725eaa73c6 , changes to MosekInterface properties names led to an issue in 
https://github.com/iFR-OFC/casos/blob/ea2c826bcfee787c1ccf422ec0af0d64138c7864/%2Bcasos/%2Bpackage/%2Bsolvers/%40MosekInterface/eval.m#L125-L138

The solution status `UNKNOWN` of Mosek causes the exception
<img width="687" height="474" alt="Screenshot from 2026-03-03 16-18-32" src="https://github.com/user-attachments/assets/247570e2-7804-4196-bbb8-681991792fa0" />

> [!NOTE]
> This issue can be replicated by running `roa_VSiteration_aircraft.m` from the [`casos-example-package`](https://github.com/iFR-OFC/casos-example-package)

This PR resolves the property naming issue above exposed, by updating the incorrect reference `obj.info` to the correct property `obj.solver_info`