### PR TITLE
Extend sparsity and indeterminates interface

### DIFF
--- a/+casos/+package/+core/@Polynomial/poly2basis.m
+++ b/+casos/+package/+core/@Polynomial/poly2basis.m
@@ -17,7 +17,7 @@ elseif isempty(obj) || (isscalar(obj) && isempty(S)) || (islogical(S) && all(~S)
     % empty polynomial, selection, or projection
     assert(~isempty(obj) || isempty(S),'Cannot project empty polynomial.')
 
-    c = sparse(0,1);
+    c = obj.new_coeff(0,1);
     S = casos.Sparsity(0,0);
     return
 

--- a/+casos/+package/+core/@Polynomial/sparsify.m
+++ b/+casos/+package/+core/@Polynomial/sparsify.m
@@ -10,7 +10,7 @@ function b = sparsify(a)
 b = a.new_poly;
 
 % sparsify coefficients
-coeffs = simplify(a.coeffs);
+coeffs = sparsify(a.coeffs);
 
 % remove zero terms
 [S,b.coeffs] = coeff_update(a.get_sparsity,coeffs);

--- a/+casos/@Indeterminates/Indeterminates.m
+++ b/+casos/@Indeterminates/Indeterminates.m
@@ -40,13 +40,13 @@ methods
         % pvar / mpvar syntax
         if nargin == 1 && ischar(var)
             % syntax Indeterminates('x')
-            obj.variables = {var};
+            variables = {var};
 
         elseif ischar([arg{:}])
             % syntax Indeterminates('x','y',...)
-            obj.variables = unique(varargin,'stable');
+            variables = unique(varargin,'stable');
 
-            if length(obj.variables) < nargin
+            if length(variables) < nargin
                 warning('Duplicate variables removed.')
             end
 
@@ -54,11 +54,14 @@ methods
             % syntax Indeterminates('x',m,n)
             N = numel(zeros(arg{:},1));     % number of variables
             l = floor(log10(N))+1;          % number of places
-            obj.variables = compose(['%s_%0' num2str(l) 'd'],var,1:N);
+            variables = compose(['%s_%0' num2str(l) 'd'],var,1:N);
 
         else
             error('Undefined syntax.')
         end
+
+        % ensure that names are stored as row vector
+        obj.variables = reshape(variables,1,[]);
     end
 
     %% Getter

--- a/+casos/@Indeterminates/Indeterminates.m
+++ b/+casos/@Indeterminates/Indeterminates.m
@@ -9,7 +9,7 @@ classdef Indeterminates < casos.package.core.AlgebraicObject & casos.package.cor
 
 properties (GetAccess=protected, SetAccess=private)
     % cell array of strings {x1,...,xN}
-    variables = {};
+    variables = cell(1,0);
 
     % transpose flag
     transp = false;

--- a/+casos/@Indeterminates/cat.m
+++ b/+casos/@Indeterminates/cat.m
@@ -19,7 +19,7 @@ if ~all([tf{:}])
 end
 
 % else:
-vars = [vars{:}];
+vars = horzcat(vars{:});    % ensure row vector
 
 % concatenate variables
 v = casos.Indeterminates(vars{:});

--- a/+casos/@Indeterminates/combine.m
+++ b/+casos/@Indeterminates/combine.m
@@ -21,11 +21,11 @@ switch (nargin)
         return
 
     case 2
-        allvars = [varargin{1}.variables varargin{2}.variables];
+        allvars = horzcat(varargin{1}.variables, varargin{2}.variables);    % ensure row vector
 
     otherwise
         allvars = cellfun(@(a) a.variables, varargin, 'UniformOutput', false);
-        allvars = [allvars{:}];
+        allvars = horzcat(allvars{:});      % ensure row vector
 end
 
 % remove duplicates and sort

--- a/+casos/@Indeterminates/parenAssign.m
+++ b/+casos/@Indeterminates/parenAssign.m
@@ -13,7 +13,7 @@ if length(indexOp) > 1
     % perform parentheses reference
     v = obj.(idx);
     % forward assign
-    [p.(indexOp(2:end))] = varargin{:};
+    [v.(indexOp(2:end))] = varargin{:};
     % re-assign modified element
     obj.(idx) = v;
 
@@ -21,7 +21,7 @@ if length(indexOp) > 1
 end
 
 % else
-assert(length(varargin) == 1, 'Too many arguments on right-hand side.')
+assert(isscalar(varargin), 'Too many arguments on right-hand side.')
 
 % assignment
 args = casos.Indeterminates(varargin{:});

--- a/+casos/@Indeterminates/parenDelete.m
+++ b/+casos/@Indeterminates/parenDelete.m
@@ -28,6 +28,6 @@ vars = obj.variables;
 vars(i{:}) = [];
 
 % return
-obj.variables = vars;
+obj.variables = reshape(vars,1,[]);     % ensure row vector
 
 end

--- a/+casos/@Indeterminates/parenReference.m
+++ b/+casos/@Indeterminates/parenReference.m
@@ -14,7 +14,8 @@ vars = obj.variables.(idx);
 
 % new indeterminates
 out = casos.Indeterminates;
-out.variables = vars;
+% ensure that names are stored as row vector
+out.variables = reshape(vars,1,[]);
 
 if length(indexOp) > 1
     % forward reference

--- a/+casos/@Sparsity/Sparsity.m
+++ b/+casos/@Sparsity/Sparsity.m
@@ -255,8 +255,8 @@ methods
         % columns are elements
         [i1,j1] = ind2sub(size(obj),col+1); % 1-index
         % return 0-indices
-        i = i1(:)-1;
-        j = j1(:)-1;
+        i = i1-1;
+        j = j1-1;
         % rows are degrees
         degrees = full(obj.degmat(row+1,:)); % 1-index
     end

--- a/+casos/@Sparsity/Sparsity.m
+++ b/+casos/@Sparsity/Sparsity.m
@@ -199,6 +199,8 @@ methods (Static)
     S = diag(varargin);
     S = dense(varargin);
 
+    S = tuplet(n,m,i,j,x,degrees);
+
     function S = band(n,p,varargin)
         % Create band sparsity pattern.
         S = casos.Sparsity(casadi.Sparsity.band(n,p),varargin{:});
@@ -245,6 +247,18 @@ methods
     function [i,j] = get_triplet(obj)
         % Return triplets for polynomial sparsity pattern.
         [i,j] = matrix_triplet(obj); % TODO
+    end
+
+    function [i,j,degrees] = get_tuplet(obj)
+        % Return tuplets for polynomial sparsity pattern.
+        [row,col] = get_triplet(obj.coeffs); % 0-index
+        % columns are elements
+        [i1,j1] = ind2sub(size(obj),col+1); % 1-index
+        % return 0-indices
+        i = i1(:)-1;
+        j = j1(:)-1;
+        % rows are degrees
+        degrees = full(obj.degmat(row+1,:)); % 1-index
     end
 
     function z = monomials(obj)

--- a/+casos/@Sparsity/tuplet.m
+++ b/+casos/@Sparsity/tuplet.m
@@ -1,0 +1,33 @@
+% SPDX-FileCopyrightText: 2026 Institute of Flight Mechanics and Controls, University of Stuttgart
+% SPDX-FileCopyrightText: Author(s): Torbjørn Cunis <tcunis@ifr.uni-stuttgart.de>
+% SPDX-FileContributor: For a full list of contributors, see <https://github.com/ifr-ofc/casos>
+%
+% SPDX-License-Identifier: GPL-3.0-only
+
+function S = tuplet(n,m,i,j,x,degrees)
+% Create sparsity pattern with tuplets.
+
+assert(n >= 0 && m >= 0,'Dimensions must be nonnegative.')
+assert(length(i) == length(j),'Mismatch of length of indices.')
+assert(all(i >= 0) && all(j >= 0),'Indices must be nonnegative.')
+assert(all(i < n) && all(j < m),'Indices out of range (%dx%d).',n,m)
+assert(is_indet(x),'x must be indeterminate variables.')
+assert(length(x) == size(degrees,2),'Mismatch of number of indeterminate variables.')
+assert(length(i) == size(degrees,1),'Mismatch of length of degrees.')
+
+S = casos.Sparsity;
+
+% convert subindices to column index
+col = sub2ind([n m],i+1,j+1); % 1-index
+
+% coefficients with nonunique degree matrix
+coeffs = casadi.Sparsity.triplet(length(col),n*m,0:length(col)-1,col-1); % 0-index
+
+% make degree matrix unique
+[S.coeffs,S.degmat] = uniqueDeg(coeffs,degrees);
+
+% set output
+S.indets = casos.Indeterminates(x);
+S.matdim = [n m];
+
+end

--- a/+casos/@Sparsity/tuplet.m
+++ b/+casos/@Sparsity/tuplet.m
@@ -24,10 +24,12 @@ col = sub2ind([n m],i+1,j+1); % 1-index
 coeffs = casadi.Sparsity.triplet(length(col),n*m,0:length(col)-1,col-1); % 0-index
 
 % make degree matrix unique
-[S.coeffs,S.degmat] = uniqueDeg(coeffs,degrees);
+[coeffs,degmat] = uniqueDeg(coeffs,degrees);
 
-% set output
-S.indets = casos.Indeterminates(x);
+% remove redundant zeros
+[S.coeffs,S.degmat,S.indets] = removeZero(coeffs,degmat,casos.Indeterminates(x));
+
+% set dimensions
 S.matdim = [n m];
 
 end


### PR DESCRIPTION
This PR extends the interface of polynomial sparsity and indeterminate variables to:

1. Introduce a tuplet notation (row and column indices and degrees) of sparsity patterns;
2. Always store variable names as row vectors (ensure comparison of indeterminates);
3. Some bug fixes.