### PR TITLE
Convenience methods for indeterminate variables

### DIFF
--- a/+casos/+package/+core/AlgebraicObject.m
+++ b/+casos/+package/+core/AlgebraicObject.m
@@ -26,19 +26,49 @@ methods
         b = transpose(a);
     end
 
-    function c = plus(a,b)
-        % Add algebraic objects.
-        c = plus(casos.package.polynomial(a),casos.package.polynomial(b));
+    function c = dot(a,b)
+        % Inner product of algebraic objects.
+        c = dot(casos.package.polynomial(a),casos.package.polynomial(b));
     end
 
-    function c = times(a,b)
-        % Multiply algebraic objects (element-wise).
-        c = times(casos.package.polynomial(a),casos.package.polynomial(b));
+    function c = kron(a,b)
+        % Kronecker product of algebraic objects.
+        c = kron(casos.package.polynomial(a),casos.package.polynomial(b));
+    end
+
+    function c = ldivide(b,a)
+        % Left-hand divide algebraic objects (element-wise).
+        c = ldivide(casos.package.polynomial(b),casos.package.polynomial(a));
+    end
+
+    function c = mldivide(b,a)
+        % Left-hand divide algebraic objects (matrix division).
+        c = mldivide(casos.package.polynomial(b),casos.package.polynomial(a));
+    end
+
+    function c = mrdivide(a,b)
+        % Right-hand divide algebraic objects (matrix division).
+        c = mrdivide(casos.package.polynomial(a),casos.package.polynomial(b));
     end
 
     function c = mtimes(a,b)
         % Multiply algebraic objects (matrix product).
         c = mtimes(casos.package.polynomial(a),casos.package.polynomial(b));
+    end
+
+    function c = plus(a,b)
+        % Add algebraic objects.
+        c = plus(casos.package.polynomial(a),casos.package.polynomial(b));
+    end
+
+    function c = rdivide(a,b)
+        % Right-hand divide algebraic objects (element-wise).
+        c = rdivide(casos.package.polynomial(a),casos.package.polynomial(b));
+    end
+
+    function c = times(a,b)
+        % Multiply algebraic objects (element-wise).
+        c = times(casos.package.polynomial(a),casos.package.polynomial(b));
     end
 
     function b = uminus(a)

--- a/+casos/@Indeterminates/Indeterminates.m
+++ b/+casos/@Indeterminates/Indeterminates.m
@@ -127,6 +127,20 @@ methods
         z = power(casos.package.polynomial(obj),deg);
     end
 
+    function z = prod(obj,~)
+        % Return product of variables.
+        z = prod(casos.package.polynomial(obj));
+    end
+
+    function c = subs(a,x,b)
+        % Substitute indeterminate variables.
+        c = subs(casos.package.polynomial(a),x,casos.package.polynomial(b));
+    end
+
+    function z = sum(obj,~)
+        % Return sum of variables.
+        z = sum(casos.package.polynomial(obj));
+    end
     function obj = transpose(obj)
         % Toggle transpose flag.
         obj.transp = ~obj.transp;

--- a/+casos/@Indeterminates/Indeterminates.m
+++ b/+casos/@Indeterminates/Indeterminates.m
@@ -4,7 +4,8 @@
 %
 % SPDX-License-Identifier: GPL-3.0-only
 
-classdef Indeterminates < casos.package.core.AlgebraicObject & casos.package.core.Printable
+classdef (InferiorClasses = {?casadi.DM, ?casadi.SX, ?casadi.MX}) ...
+    Indeterminates < casos.package.core.AlgebraicObject & casos.package.core.Printable
 % Indeterminate variables.
 
 properties (GetAccess=protected, SetAccess=private)

--- a/+casos/@Indeterminates/Indeterminates.m
+++ b/+casos/@Indeterminates/Indeterminates.m
@@ -118,8 +118,16 @@ methods
     function tf = is_indet(~), tf = true; end
 
     function z = mpower(obj,deg)
-        % Return monomial(s).
-        z = power(casos.package.polynomial(obj),deg);
+        % Return sum of monomial(s).
+        %
+        % For an even degree p, this corresponds to the p-norm ||x||_p 
+        % of the vector x to the power of p.
+        if ~isscalar(deg)
+            error('Power of indeterminates must be scalar.'); 
+        end
+        
+        % else:
+        z = sum(power(obj,deg));
     end
 
     function z = power(obj,deg)

--- a/+casos/@Indeterminates/Indeterminates.m
+++ b/+casos/@Indeterminates/Indeterminates.m
@@ -7,6 +7,26 @@
 classdef (InferiorClasses = {?casadi.DM, ?casadi.SX, ?casadi.MX}) ...
     Indeterminates < casos.package.core.AlgebraicObject & casos.package.core.Printable
 % Indeterminate variables.
+%
+%% Constructor summary:
+%
+%   Indeterminates()
+%
+% create empty list of indeterminate variables.
+%
+%   Indeterminates(char, ...)
+%   Indeterminates(char, int)
+%
+% create list of indeterminate variables.
+%
+%% Static constructor summary:
+%
+%   [x1, ...] = create(char, ...)
+%   [x1, ...] = create(char, int)
+%
+% create indeterminate variables individually.
+%
+%%
 
 properties (GetAccess=protected, SetAccess=private)
     % cell array of strings {x1,...,xN}
@@ -105,7 +125,11 @@ methods (Static)
     end
 
     function varargout = create(varargin)
-        % Create individual indeterminate variables.
+        % Create indeterminate variables individually.
+        %
+        %   [x1, ...] = create(char, ...)
+        %   [x1, ...] = create(char, int)
+        %
         varargout = tuple2cell(casos.Indeterminates(varargin{:}));
     end
 end

--- a/+casos/@Indeterminates/Indeterminates.m
+++ b/+casos/@Indeterminates/Indeterminates.m
@@ -102,6 +102,11 @@ methods (Static)
         % Create empty indeterminate variables.
         v = casos.Indeterminates;
     end
+
+    function varargout = create(varargin)
+        % Create individual indeterminate variables.
+        varargout = tuple2cell(casos.Indeterminates(varargin{:}));
+    end
 end
 
 methods
@@ -144,6 +149,12 @@ methods (Access=protected)
     obj = parenAssign(obj,idx,varargin);
     obj = parenDelete(obj,idx);
     varargout = parenReference(obj,index);
+
+    % Convert to cell of single variables
+    function cell_of_indets = tuple2cell(obj)
+        % Return a cell array of individual indeterminate variables.
+        cell_of_indets = cellfun(@(var) casos.Indeterminates(var), obj.variables, 'UniformOutput', false);
+    end
 end
 
 methods (Access={?casos.package.core.PolynomialInterface})


### PR DESCRIPTION
This PR adds convenience methods for indeterminate variables and extends their polynomial interface:

- Multiple indeterminate variables can now be created en bloc via the syntax
  ```
  [x,y,t] = casos.Indeterminates.create('x', 'y', 't');
  ```

- Addition, multiplication (including inner and Kronecker product), and division (element-wise and matrix divide) of indeterminate variables with non-polynomial data types (including CasADi matrix types) as well as sum and product of indeterminate variables behave as if applied to a polynomial vector of indeterminate variables, e.g.:
  ```
  x = casos.Indeterminates('x');
  a = casadi.SX.sym('a');

  % divide x by scalar symbolic variable
  p = a\x;
  q = x/a;

  % equivalent to:
  P = a\casos.PD(x);
  Q = casos.PD(x)/a;
  ```

- **BREAKING**: Matrix-power of indeterminate variables (syntax `x^p`) returns the *sum* of element-wise powers to `p`. If `p` is even, this corresponds to the $p$-norm of $x$ to the power of $p$, that is, $|| x ||_p^p$. Element-wise power (`x.^p`) still returns a vector of indeterminate variables to the power of `p` as polynomial data type.