### PR TITLE
Fixes polynomial arithmetics from unit tests

### DIFF
--- a/+casos/+package/+core/@Polynomial/basis.m
+++ b/+casos/+package/+core/@Polynomial/basis.m
@@ -15,6 +15,14 @@ if nargin < 2
     warning('Deprecated: Use sparsity() instead.')
     S = sparsity(p);
 
+elseif (numel(p) ~= length(I))
+    % dimension mismatch
+    error('Dimension mismatch.')
+
+elseif isempty(p) || all(~I)
+    % return empty basis
+    S = casos.Sparsity(0,1);
+
 else
     % return sparsity of subindex
     S = sub(p.get_sparsity,find(I),casos.Sparsity(nnz(I),1));

--- a/+casos/+package/+core/@Polynomial/cat.m
+++ b/+casos/+package/+core/@Polynomial/cat.m
@@ -4,38 +4,52 @@
 %
 % SPDX-License-Identifier: GPL-3.0-only
 
-function p = cat(dim,varargin)
+function c = cat(dim,varargin)
 % Concatenate polynomials along specified dimension.
 %
 % Overwriting matlab.mixin.indexing.RedefinesParen.cat
 
 if nargin ~= 3
     % handle non-binary concatenation
-    p = cat@casos.package.core.PolynomialInterface(dim,varargin{:});
+    c = cat@casos.package.core.PolynomialInterface(dim,varargin{:});
     return
 end
 
 % else: two polynomials given
-p1 = varargin{1};
-p2 = varargin{2};
+a = varargin{1};
+b = varargin{2};
 
 switch (dim)
     case 0
         % block diagonal
-        ul = p1.zeros(size(p1,1),size(p2,2));
-        rl = p1.zeros(size(p2,1),size(p1,2));
+        ul = a.zeros(size(a,1),size(b,2));
+        rl = a.zeros(size(b,1),size(a,2));
 
         % concatenate all blocks
-        p = blockcat(p1,ul,rl,p2);
+        c = blockcat(a,ul,rl,b);
 
     otherwise
+        if isempty(a)
+            % concatenation with empty polynomial
+            c = b;
+            return
+        
+        elseif isempty(b)
+            c = a;
+            return
+
+        elseif (size(a,3-dim) ~= size(b,3-dim))
+            % dimensions are consistent if size(a,~dim) == size(b,~dim)
+            throw(casos.package.core.IncompatibleSizesError.concat(a,b));
+        end
+
         % generic concatenation
-        p = p1.new_poly;
+        c = a.new_poly;
 
         % concatenate coefficient matrices
-        [S,p.coeffs] = coeff_cat(p1.get_sparsity,p2.get_sparsity,p1.coeffs,p2.coeffs,dim);
+        [S,c.coeffs] = coeff_cat(a.get_sparsity,b.get_sparsity,a.coeffs,b.coeffs,dim);
         % set sparsity
-        p = set_sparsity(p,S);
+        c = set_sparsity(c,S);
 end
 
 end

--- a/+casos/+package/+core/@Polynomial/cat.m
+++ b/+casos/+package/+core/@Polynomial/cat.m
@@ -29,12 +29,20 @@ switch (dim)
         c = blockcat(a,ul,rl,b);
 
     otherwise
-        if isempty(a)
-            % concatenation with empty polynomial
+        if (isempty(a) && isempty(b))
+            % concatenation of empty polynomials
+            sz = size(a) + size(b);
+            sz(dim) = 0;        % result is empty along dimension
+            c = a.empty(sz);
+            return
+
+        elseif isempty(a)
+            % concatenation of b with empty polynomial
             c = b;
             return
         
         elseif isempty(b)
+            % concatenation of a with empty polynomial
             c = a;
             return
 

--- a/+casos/+package/+core/@Polynomial/cat.m
+++ b/+casos/+package/+core/@Polynomial/cat.m
@@ -31,8 +31,17 @@ switch (dim)
     otherwise
         if (isempty(a) && isempty(b))
             % concatenation of empty polynomials
-            sz = size(a) + size(b);
-            sz(dim) = 0;        % result is empty along dimension
+            sza = size(a);
+            szb = size(b);
+
+            if (sza(3-dim) == 0 && szb(3-dim) == 0)
+                % concatenate along non-empty dimension
+                sz = sza + szb;
+            else
+                % result is empty along dimension
+                sz(dim) = min(sza(dim), szb(dim));
+                sz(3-dim) = max(sza(3-dim), szb(3-dim));
+            end
             c = a.empty(sz);
             return
 

--- a/+casos/+package/+core/@Polynomial/cat.m
+++ b/+casos/+package/+core/@Polynomial/cat.m
@@ -29,19 +29,14 @@ switch (dim)
         c = blockcat(a,ul,rl,b);
 
     otherwise
-        if (isempty(a) && isempty(b))
-            % concatenation of empty polynomials
-            sza = size(a);
-            szb = size(b);
+        [tf,sz] = check_sz_concat(dim,a,b);
 
-            if (sza(3-dim) == 0 && szb(3-dim) == 0)
-                % concatenate along non-empty dimension
-                sz = sza + szb;
-            else
-                % result is empty along dimension
-                sz(dim) = min(sza(dim), szb(dim));
-                sz(3-dim) = max(sza(3-dim), szb(3-dim));
-            end
+        if (~tf)
+            % dimensions are consistent if size(a,~dim) == size(b,~dim)
+            throw(casos.package.core.IncompatibleSizesError.concat(a,b));
+
+        elseif (isempty(a) && isempty(b))
+            % concatenation of empty polynomials
             c = a.empty(sz);
             return
 
@@ -54,10 +49,6 @@ switch (dim)
             % concatenation of a with empty polynomial
             c = a;
             return
-
-        elseif (size(a,3-dim) ~= size(b,3-dim))
-            % dimensions are consistent if size(a,~dim) == size(b,~dim)
-            throw(casos.package.core.IncompatibleSizesError.concat(a,b));
         end
 
         % generic concatenation

--- a/+casos/+package/+core/@Polynomial/densify.m
+++ b/+casos/+package/+core/@Polynomial/densify.m
@@ -1,0 +1,21 @@
+% SPDX-FileCopyrightText: 2026 Institute of Flight Mechanics and Controls, University of Stuttgart
+% SPDX-FileCopyrightText: Author(s): Torbjørn Cunis <tcunis@ifr.uni-stuttgart.de>
+% SPDX-FileContributor: For a full list of contributors, see <https://github.com/ifr-ofc/casos>
+%
+% SPDX-License-Identifier: GPL-3.0-only
+
+function b = densify(a)
+% Densify polynomial expressions.
+
+b = a.new_poly;
+
+% sparsify coefficients
+coeffs = densify(a.coeffs);
+
+% remove zero terms
+[S,b.coeffs] = coeff_update(a.get_sparsity,coeffs);
+
+% set sparsity
+b = set_sparsity(b,S);
+
+end

--- a/+casos/+package/+core/@Polynomial/dot.m
+++ b/+casos/+package/+core/@Polynomial/dot.m
@@ -4,15 +4,18 @@
 %
 % SPDX-License-Identifier: GPL-3.0-only
 
-function r = dot(p,q)
+function c = dot(a,b)
 % Scalar dot product of two polynomials.
 
-assert(numel(p) == numel(q),'Inputs must be of compatible size.')
+if ~check_sz_equal(a,b)
+    % dimension mismatch
+    throw(casos.package.core.IncompatibleSizesError.other(a,b));
+end
 
 % expand coefficient matrices to match
-[cf1,cf2] = coeff_expand(p.get_sparsity,q.get_sparsity,p.coeffs,q.coeffs);
+[cf1,cf2] = coeff_expand(a.get_sparsity,b.get_sparsity,a.coeffs,b.coeffs);
 
 % return dot product of coefficients
-r = dot(cf1,cf2);
+c = dot(cf1,cf2);
 
 end

--- a/+casos/+package/+core/@Polynomial/ldivide.m
+++ b/+casos/+package/+core/@Polynomial/ldivide.m
@@ -13,22 +13,16 @@ assert(is_zerodegree(a),'Only division by constant or symbolic matrix possible.'
 sza = size(a);
 szp = size(p);
 
-% find zero dimension
-I0 = (sza == 0) | (szp == 0);
-
 % dimensions are compatible if equal or one summand is row/column
-if ~check_sz_basic(a,p)
+[tf,sz] = check_sz_basic(a,p);
+
+if (~tf)
     throw(casos.package.core.IncompatibleSizesError.basic(a,p));
 end
-
-% dimensions of element-wise product
-sz = max(sza,szp);
 
 % handle simple case(s) for speed up
 if isempty(a) || isempty(p)
     % element-wise multiplication with empty polynomial is empty
-    sz(I0) = 0;
-
     c = p.empty(sz);
     return
 end

--- a/+casos/+package/+core/@Polynomial/ldivide.m
+++ b/+casos/+package/+core/@Polynomial/ldivide.m
@@ -17,7 +17,7 @@ szp = size(p);
 I0 = (sza == 0) | (szp == 0);
 
 % dimensions are compatible if equal or one summand is row/column
-if ~check_sz_comptbl(a,p)
+if ~check_sz_basic(a,p)
     throw(casos.package.core.IncompatibleSizesError.basic(a,p));
 end
 

--- a/+casos/+package/+core/@Polynomial/mpower.m
+++ b/+casos/+package/+core/@Polynomial/mpower.m
@@ -7,10 +7,11 @@
 function b = mpower(a,n)
 % Power of polynomial matrix.
 
-assert(size(a,1) == size(a,2), 'Matrix must be square.')
-assert(isscalar(n), 'Exponent must be scalar.')
+if ~check_sz_square(a) || ~isscalar(n)
+    % dimensions are compatible if a is square and n is scalar
+    throw(casos.package.core.IncompatibleSizesError.mpower(a,n));
 
-if isscalar(a)
+elseif isscalar(a)
     % fall back to scalar power.
     b = power(a,n);
     return

--- a/+casos/+package/+core/@Polynomial/mtimes.m
+++ b/+casos/+package/+core/@Polynomial/mtimes.m
@@ -7,12 +7,7 @@
 function c = mtimes(a,b)
 % Matrix multiplication of two polynomials.
 
-if isempty(a) || isempty(b)
-    % empty multiplication
-    c = a.zeros(size(a,1),size(b,2));
-    return
-
-elseif isscalar(a) || isscalar(b)
+if isscalar(a) || isscalar(b)
     % fall back to scalar multiplication
     c = times(a,b);
     return
@@ -20,6 +15,11 @@ elseif isscalar(a) || isscalar(b)
 elseif ~check_sz_mtimes(a,b)
     % dimensions are compatible if size(a,2) == size(b,1)
     throw(casos.package.core.IncompatibleSizesError.matrix(a,b));
+
+elseif isempty(a) || isempty(b)
+    % empty multiplication
+    c = a.zeros(size(a,1),size(b,2));
+    return
 end
 
 % else

--- a/+casos/+package/+core/@Polynomial/mtimes.m
+++ b/+casos/+package/+core/@Polynomial/mtimes.m
@@ -12,7 +12,7 @@ if isscalar(a) || isscalar(b)
     c = times(a,b);
     return
 
-elseif ~check_sz_mtimes(a,b)
+elseif ~check_sz_matrix(a,b)
     % dimensions are compatible if size(a,2) == size(b,1)
     throw(casos.package.core.IncompatibleSizesError.matrix(a,b));
 

--- a/+casos/+package/+core/@Polynomial/nabla.m
+++ b/+casos/+package/+core/@Polynomial/nabla.m
@@ -9,6 +9,12 @@ function g = nabla(f,x)
 
 assert(is_indet(x), 'Second argument must be vector of indeterminates.')
 
+if (isempty(f) || isempty(x))
+    % empty Jacobian matrix
+    g = f.empty(numel(f),length(x));
+    return
+end
+
 g = f.new_poly;
 
 % compute coefficient matrix of Jacobian

--- a/+casos/+package/+core/@Polynomial/parenAssign.m
+++ b/+casos/+package/+core/@Polynomial/parenAssign.m
@@ -30,7 +30,7 @@ lhs = I.(idx);
 
 % dimensions are compatible if equal or right side is row/column
 if ~check_sz_assign(lhs,q)
-    throw(casos.package.core.IncompatibleSizesError.other(lhs,q))
+    throw(casos.package.core.IncompatibleSizesError.assign(lhs,q))
 end
 
 % reshape coefficients to referenced size

--- a/+casos/+package/+core/@Polynomial/plus.m
+++ b/+casos/+package/+core/@Polynomial/plus.m
@@ -11,22 +11,16 @@ function c = plus(a,b)
 sza = size(a);
 szb = size(b);
 
-% find zero dimension
-I0 = (sza == 0) | (szb == 0);
-
 % dimensions are compatible if equal or one summand is row/column
-if ~check_sz_basic(a,b)
+[tf,sz] = check_sz_basic(a,b);
+
+if (~tf)
     throw(casos.package.core.IncompatibleSizesError.basic(a,b));
 end
-
-% dimensions of sum
-sz = max(sza,szb);
 
 % handle simple case(s) for speed up
 if isempty(a) || isempty(b)
     % addition with empty polynomial is empty
-    sz(I0) = 0;
-
     c = a.empty(sz);
     return
 end

--- a/+casos/+package/+core/@Polynomial/plus.m
+++ b/+casos/+package/+core/@Polynomial/plus.m
@@ -15,7 +15,7 @@ szb = size(b);
 I0 = (sza == 0) | (szb == 0);
 
 % dimensions are compatible if equal or one summand is row/column
-if ~check_sz_comptbl(a,b)
+if ~check_sz_basic(a,b)
     throw(casos.package.core.IncompatibleSizesError.basic(a,b));
 end
 

--- a/+casos/+package/+core/@Polynomial/poly2basis.m
+++ b/+casos/+package/+core/@Polynomial/poly2basis.m
@@ -13,6 +13,10 @@ if nargin < 2
     S = sparsity(obj);
     coeffs = obj.coeffs;
 
+elseif ~isscalar(obj) && ~islogical(S) && ~check_sz_equal(obj,S)
+    % dimension mismatch
+    throw(casos.package.core.IncompatibleSizesError.other(obj,S));
+
 elseif isempty(obj) || (isscalar(obj) && isempty(S)) || (islogical(S) && all(~S))
     % empty polynomial, selection, or projection
     assert(~isempty(obj) || isempty(S),'Cannot project empty polynomial.')

--- a/+casos/+package/+core/@Polynomial/poly2basis.m
+++ b/+casos/+package/+core/@Polynomial/poly2basis.m
@@ -14,7 +14,7 @@ if nargin < 2
     coeffs = obj.coeffs;
 
 elseif ~isscalar(obj) && ~islogical(S) ...
-         && ~(isempty(obj) && isempty(S)) && ~check_sz_equal(obj,S)
+         && ~(all(size(obj) == 0) && isempty(S)) && ~check_sz_equal(obj,S)
     % dimension mismatch
     throw(casos.package.core.IncompatibleSizesError.other(obj,S));
 

--- a/+casos/+package/+core/@Polynomial/poly2basis.m
+++ b/+casos/+package/+core/@Polynomial/poly2basis.m
@@ -13,7 +13,8 @@ if nargin < 2
     S = sparsity(obj);
     coeffs = obj.coeffs;
 
-elseif ~isscalar(obj) && ~islogical(S) && ~check_sz_equal(obj,S)
+elseif ~isscalar(obj) && ~islogical(S) ...
+         && ~(isempty(obj) && isempty(S)) && ~check_sz_equal(obj,S)
     % dimension mismatch
     throw(casos.package.core.IncompatibleSizesError.other(obj,S));
 

--- a/+casos/+package/+core/@Polynomial/power.m
+++ b/+casos/+package/+core/@Polynomial/power.m
@@ -27,7 +27,7 @@ if isempty(a) || isempty(n)
     % element-wise power with empty polynomial/exponent is empty
     sz(I0) = 0;
 
-    b = a.new_poly(sz);
+    b = a.zeros(sz);
     return
 
 elseif all(n==0)

--- a/+casos/+package/+core/@Polynomial/power.m
+++ b/+casos/+package/+core/@Polynomial/power.m
@@ -15,7 +15,7 @@ szn = size(n);
 I0 = (sza == 0) | (szn == 0);
 
 % dimensions are compatible if equal or one summand is row/column
-if ~check_sz_comptbl(a,n)
+if ~check_sz_basic(a,n)
     throw(casos.package.core.IncompatibleSizesError.basic(a,n));
 end
 

--- a/+casos/+package/+core/@Polynomial/power.m
+++ b/+casos/+package/+core/@Polynomial/power.m
@@ -11,22 +11,16 @@ function b = power(a,n)
 sza = size(a);
 szn = size(n);
 
-% find zero dimension
-I0 = (sza == 0) | (szn == 0);
-
 % dimensions are compatible if equal or one summand is row/column
-if ~check_sz_basic(a,n)
+[tf,sz] = check_sz_basic(a,n);
+
+if (~tf)
     throw(casos.package.core.IncompatibleSizesError.basic(a,n));
 end
-
-% dimensions of sum
-sz = max(sza,szn);
 
 % handle simple case(s) for speed up
 if isempty(a) || isempty(n)
     % element-wise power with empty polynomial/exponent is empty
-    sz(I0) = 0;
-
     b = a.zeros(sz);
     return
 

--- a/+casos/+package/+core/@Polynomial/rdivide.m
+++ b/+casos/+package/+core/@Polynomial/rdivide.m
@@ -17,7 +17,7 @@ szb = size(b);
 I0 = (szp == 0) | (szb == 0);
 
 % dimensions are compatible if equal or one summand is row/column
-if ~check_sz_comptbl(p,b)
+if ~check_sz_basic(p,b)
     throw(casos.package.core.IncompatibleSizesError.basic(p,b));
 end
 

--- a/+casos/+package/+core/@Polynomial/rdivide.m
+++ b/+casos/+package/+core/@Polynomial/rdivide.m
@@ -13,22 +13,16 @@ assert(is_zerodegree(b),'Only division by constant or symbolic matrix possible.'
 szp = size(p);
 szb = size(b);
 
-% find zero dimension
-I0 = (szp == 0) | (szb == 0);
-
 % dimensions are compatible if equal or one summand is row/column
-if ~check_sz_basic(p,b)
+[tf,sz] = check_sz_basic(p,b);
+
+if (~tf)
     throw(casos.package.core.IncompatibleSizesError.basic(p,b));
 end
-
-% dimensions of element-wise product
-sz = max(szp,szb);
 
 % handle simple case(s) for speed up
 if isempty(p) || isempty(b)
     % element-wise multiplication with empty polynomial is empty
-    sz(I0) = 0;
-
     c = p.empty(sz);
     return
 end

--- a/+casos/+package/+core/@Polynomial/subs.m
+++ b/+casos/+package/+core/@Polynomial/subs.m
@@ -18,8 +18,9 @@ elseif (size(x,1) == size(b,1) && iscolumn(x) && size(b,2) > 1)
     % repeated substitution -- not supported
     error('Repeated substitution not supported, use to_function(a) instead.')
 
-else
-    assert(numel(x) == numel(b),'Second and third argument have incompatible sizes.')
+elseif ~isequal(numel(x), numel(b))
+    % number of elements to be substituted is incompatible
+    throw(casos.package.core.IncompatibleSizesError.substitute(x,b));
 end
 
 c = a.new_poly;

--- a/+casos/+package/+core/@Polynomial/times.m
+++ b/+casos/+package/+core/@Polynomial/times.m
@@ -11,22 +11,16 @@ function c = times(a,b)
 sza = size(a);
 szb = size(b);
 
-% find zero dimension
-I0 = (sza == 0) | (szb == 0);
-
 % dimensions are compatible if equal or one summand is row/column
-if ~check_sz_basic(a,b)
+[tf,sz] = check_sz_basic(a,b);
+
+if (~tf)
     throw(casos.package.core.IncompatibleSizesError.basic(a,b));
 end
-
-% dimensions of element-wise product
-sz = max(sza,szb);
 
 % handle simple case(s) for speed up
 if isempty(a) || isempty(b)
     % element-wise multiplication with empty polynomial is empty
-    sz(I0) = 0;
-
     c = a.empty(sz);
     return
 end

--- a/+casos/+package/+core/@Polynomial/times.m
+++ b/+casos/+package/+core/@Polynomial/times.m
@@ -15,7 +15,7 @@ szb = size(b);
 I0 = (sza == 0) | (szb == 0);
 
 % dimensions are compatible if equal or one summand is row/column
-if ~check_sz_comptbl(a,b)
+if ~check_sz_basic(a,b)
     throw(casos.package.core.IncompatibleSizesError.basic(a,b));
 end
 

--- a/+casos/+package/+core/IncompatibleSizesError.m
+++ b/+casos/+package/+core/IncompatibleSizesError.m
@@ -15,6 +15,13 @@ methods (Access=protected)
 end
 
 methods (Static)
+    function err = assign(a,b)
+        % New error for assignment operation.
+        err = casos.package.core.IncompatibleSizesError('MATLAB:subsassigndimmismatch', ...
+                ['Unable to perform assignment because the size of the left polynomial is [%s]' ...
+                ' and the size of the right polynomial is [%s].'],a,b);
+    end
+
     function err = basic(a,b)
         % New error for basic operation.
         err = casos.package.core.IncompatibleSizesError('MATLAB:sizeDimensionsMustMatch', ...
@@ -31,6 +38,19 @@ methods (Static)
         % New error for matrix operation.
         err = casos.package.core.IncompatibleSizesError('MATLAB:innerdim', ...
                 'Incorrect dimensions for polynomial matrix multiplication: [%s] vs. [%s].',a,b);
+    end
+
+    function err = mpower(a,b)
+        % New error for matrix power.
+        err = casos.package.core.IncompatibleSizesError('MATLAB:mpower:notScalarAndSquareMatrix', ...
+                'Incorrect dimensions for raising a polynomial matrix to a power: [%s] and [%s].',a,b);
+    end
+
+    function err = substitute(a,b)
+        % New error for substitution.
+        err = casos.package.core.IncompatibleSizesError('', ...
+                ['Unable to perform substitution because the size of the indeterminate variables is [%s]' ...
+                ' and the size of the polynomial to be substituted into is [%s].'],a,b);
     end
 
     function err = other(a,b)

--- a/+casos/+package/+core/IncompatibleSizesError.m
+++ b/+casos/+package/+core/IncompatibleSizesError.m
@@ -14,6 +14,15 @@ methods (Access=protected)
     end
 end
 
+methods
+    function msgtext = getReport(err,varargin)
+        % Return formatted error message text.
+        if nargin < 2, varargin = {'basic'}; end % omit stack from report
+
+        msgtext = getReport@MException(err,varargin{:});
+    end
+end
+
 methods (Static)
     function err = assign(a,b)
         % New error for assignment operation.

--- a/+casos/+package/+core/IncompatibleSizesError.m
+++ b/+casos/+package/+core/IncompatibleSizesError.m
@@ -22,6 +22,11 @@ methods (Static)
         err = casos.package.core.IncompatibleSizesError('MATLAB:sizeDimensionsMustMatch',a,b);
     end
 
+    function err = concat(a,b)
+        % New error for concatenation.
+        err = casos.package.core.IncompatibleSizesError('MATLAB:catenate:dimensionMismatch',a,b);
+    end
+
     function err = matrix(a,b)
         % New error for matrix operation.
         err = casos.package.core.IncompatibleSizesError('MATLAB:innerdim',a,b);

--- a/+casos/+package/+core/IncompatibleSizesError.m
+++ b/+casos/+package/+core/IncompatibleSizesError.m
@@ -8,33 +8,35 @@ classdef IncompatibleSizesError < MException
 % Error thrown if inputs have compatible sizes for an operation.
 
 methods (Access=protected)
-    function err = IncompatibleSizesError(id,a,b)
+    function err = IncompatibleSizesError(id,msg,a,b)
         % New error with identifier.
-        errsz = 'Polynomials have incompatible sizes for this operation ([%s] vs. [%s]).';
-        
-        err@MException(id,errsz,size2str(a),size2str(b));
+        err@MException(id,msg,size2str(a),size2str(b));
     end
 end
 
 methods (Static)
     function err = basic(a,b)
         % New error for basic operation.
-        err = casos.package.core.IncompatibleSizesError('MATLAB:sizeDimensionsMustMatch',a,b);
+        err = casos.package.core.IncompatibleSizesError('MATLAB:sizeDimensionsMustMatch', ...
+                'Polynomials have incompatible sizes for this operation: [%s] vs. [%s].',a,b);
     end
 
     function err = concat(a,b)
         % New error for concatenation.
-        err = casos.package.core.IncompatibleSizesError('MATLAB:catenate:dimensionMismatch',a,b);
+        err = casos.package.core.IncompatibleSizesError('MATLAB:catenate:dimensionMismatch', ...
+                'Dimensions of polynomials being concatenated are not consistent: [%s] vs. [%s].',a,b);
     end
 
     function err = matrix(a,b)
         % New error for matrix operation.
-        err = casos.package.core.IncompatibleSizesError('MATLAB:innerdim',a,b);
+        err = casos.package.core.IncompatibleSizesError('MATLAB:innerdim', ...
+                'Incorrect dimensions for polynomial matrix multiplication: [%s] vs. [%s].',a,b);
     end
 
     function err = other(a,b)
         % New error for other operations.
-        err = casos.package.core.IncompatibleSizesError('',a,b);
+        err = casos.package.core.IncompatibleSizesError('', ...
+                'Polynomial dimension mismatch: [%s] vs. [%s].',a,b);
     end
 end
 

--- a/+casos/+package/+core/PolynomialInterface.m
+++ b/+casos/+package/+core/PolynomialInterface.m
@@ -81,6 +81,11 @@ methods (Access=protected)
         % Check if sizes are compatible for matrix multiplication.
         tf = size(a,2) == size(b,1);
     end
+
+    function tf = check_sz_square(a)
+        % Check if matrix is square.
+        tf = isequal(size(a,1),size(a,2));
+    end
 end
 
 end

--- a/+casos/+package/+core/PolynomialInterface.m
+++ b/+casos/+package/+core/PolynomialInterface.m
@@ -48,16 +48,18 @@ end
 
 methods (Access=protected)
     %% Utilities
-    function tf = check_sz_assign(a,b)
+    function [tf,sz] = check_sz_assign(a,b)
         % Check if sizes are compatible for matrix assignment.
         sza = size(a);
         szb = size(b);
 
         % dimensions are compatible if equal or right side is row/column
         tf = all(sza == szb | szb == 1);
+        % size of left side does not change
+        sz = sza;
     end
 
-    function tf = check_sz_basic(a,b)
+    function [tf,sz] = check_sz_basic(a,b)
         % Check if sizes are compatible for basic (array) operations.
         % input dimensions
         sza = size(a);
@@ -65,26 +67,36 @@ methods (Access=protected)
         
         % compare dimensions
         I = (sza == szb);
+        % find zero dimension
+        I0 = (sza == 0) | (szb == 0);
         % find one dimension
         I1 = (sza == 1) | (szb == 1);
         
         % dimensions are compatible if equal or one summand is row/column
         tf = all(I | I1);
+
+        % dimensions of result
+        sz = max(sza,szb);
+        % operation with empty operands is empty
+        sz(I0) = 0;
     end
 
-    function tf = check_sz_equal(a,b)
+    function [tf,sz] = check_sz_equal(a,b)
         % Check if two objects have same size.
-        tf = isequal(size(a),size(b));
+        sz = size(a);
+        tf = isequal(sz,size(b));
     end
 
-    function tf = check_sz_matrix(a,b)
+    function [tf,sz] = check_sz_matrix(a,b)
         % Check if sizes are compatible for matrix multiplication.
         tf = size(a,2) == size(b,1);
+        sz = [size(a,1) size(b,2)];
     end
 
-    function tf = check_sz_square(a)
+    function [tf,sz] = check_sz_square(a)
         % Check if matrix is square.
-        tf = isequal(size(a,1),size(a,2));
+        sz = size(a);
+        tf = isequal(sz(1),sz(2));
     end
 end
 

--- a/+casos/+package/+core/PolynomialInterface.m
+++ b/+casos/+package/+core/PolynomialInterface.m
@@ -48,12 +48,16 @@ end
 
 methods (Access=protected)
     %% Utilities
-    function tf = check_sz_equal(a,b)
-        % Check if two objects have same size.
-        tf = isequal(size(a),size(b));
+    function tf = check_sz_assign(a,b)
+        % Check if sizes are compatible for matrix assignment.
+        sza = size(a);
+        szb = size(b);
+
+        % dimensions are compatible if equal or right side is row/column
+        tf = all(sza == szb | szb == 1);
     end
 
-    function tf = check_sz_comptbl(a,b)
+    function tf = check_sz_basic(a,b)
         % Check if sizes are compatible for basic (array) operations.
         % input dimensions
         sza = size(a);
@@ -68,16 +72,12 @@ methods (Access=protected)
         tf = all(I | I1);
     end
 
-    function tf = check_sz_assign(a,b)
-        % Check if sizes are compatible for matrix assignment.
-        sza = size(a);
-        szb = size(b);
-
-        % dimensions are compatible if equal or right side is row/column
-        tf = all(sza == szb | szb == 1);
+    function tf = check_sz_equal(a,b)
+        % Check if two objects have same size.
+        tf = isequal(size(a),size(b));
     end
 
-    function tf = check_sz_mtimes(a,b)
+    function tf = check_sz_matrix(a,b)
         % Check if sizes are compatible for matrix multiplication.
         tf = size(a,2) == size(b,1);
     end

--- a/+casos/+package/+core/PolynomialInterface.m
+++ b/+casos/+package/+core/PolynomialInterface.m
@@ -61,7 +61,6 @@ methods (Access=protected)
 
     function [tf,sz] = check_sz_basic(a,b)
         % Check if sizes are compatible for basic (array) operations.
-        % input dimensions
         sza = size(a);
         szb = size(b);
         
@@ -79,6 +78,38 @@ methods (Access=protected)
         sz = max(sza,szb);
         % operation with empty operands is empty
         sz(I0) = 0;
+    end
+
+    function [tf,sz] = check_sz_concat(dim,a,b)
+        % Check if sizes are compatible for concatenation.
+        sza = size(a);
+        szb = size(b);
+
+        % find zero dimension
+        I0 = (sza == 0) | (szb == 0);
+
+        % dimensions are consistent if size(a,~dim) == size(b,~dim)
+        % unless either operand is empty or diagonal concatenation
+        tf = (dim == 0) || any(I0) || (sza(3-dim) == (szb(3-dim)));
+
+        if (dim == 0) || (sza(3-dim) == 0 && szb(3-dim) == 0)
+            % concatenate both (non-empty) dimensions
+            sz = sza + szb;
+        elseif any(sza == 0) && any(szb == 0)
+            % concatenation of empty polynomials
+            sz(dim) = min(sza(dim), szb(dim));
+            sz(3-dim) = max(sza(3-dim), szb(3-dim));
+        elseif any(sza == 0)
+            % concatenation of b with empty polynomial
+            sz = szb;
+        elseif any(szb == 0)
+            % concatenation of a with empty polynomial
+            sz = sza;
+        else
+            % concatenate along dimension
+            sz(dim) = sza(dim) + szb(dim);
+            sz(3-dim) = sza(3-dim);
+        end
     end
 
     function [tf,sz] = check_sz_equal(a,b)

--- a/+casos/@Sparsity/cat.m
+++ b/+casos/@Sparsity/cat.m
@@ -19,8 +19,14 @@ end
 a = casos.Sparsity(varargin{1});
 b = casos.Sparsity(varargin{2});
 
-% detect empty polynomials
-if isempty(a)
+% concatenation with empty polynomial
+if (isempty(a) && isempty(b))
+    sz = size(a) + size(b);
+    sz(dim) = 0;            % result is empty along dimension
+    c = casos.Sparsity(sz);
+    return
+
+elseif isempty(a)
     c = b;
     return
 

--- a/+casos/@Sparsity/cat.m
+++ b/+casos/@Sparsity/cat.m
@@ -4,22 +4,36 @@
 %
 % SPDX-License-Identifier: GPL-3.0-only
 
-function S = cat(dim,varargin)
+function c = cat(dim,varargin)
 % Concatenate polynomial sparsity patterns along specified dimension.
 %
 % Overwriting matlab.mixin.indexing.RedefinesParen.cat
 
 if nargin ~= 3
     % handle non-binary concatenation
-    S = cat@casos.package.core.PolynomialInterface(dim,varargin{:});
+    c = cat@casos.package.core.PolynomialInterface(dim,varargin{:});
     return
 end
 
 % two patterns given
-S1 = casos.Sparsity(varargin{1});
-S2 = casos.Sparsity(varargin{2});
+a = casos.Sparsity(varargin{1});
+b = casos.Sparsity(varargin{2});
+
+% detect empty polynomials
+if isempty(a)
+    c = b;
+    return
+
+elseif isempty(b)
+    c = a;
+    return
+
+elseif (size(a,3-dim) ~= size(b,3-dim))
+    % dimensions are consistent if size(a,~dim) == size(b,~dim)
+    throw(casos.package.core.IncompatibleSizesError.concat(a,b));
+end
 
 % concatenate coefficient matrices
-S = coeff_cat(S1,S2,S1.coeffs,S2.coeffs,dim);
+c = coeff_cat(a,b,a.coeffs,b.coeffs,dim);
 
 end

--- a/+casos/@Sparsity/cat.m
+++ b/+casos/@Sparsity/cat.m
@@ -19,24 +19,28 @@ end
 a = casos.Sparsity(varargin{1});
 b = casos.Sparsity(varargin{2});
 
-% concatenation with empty polynomial
-if (isempty(a) && isempty(b))
-    sz = size(a) + size(b);
-    sz(dim) = 0;            % result is empty along dimension
+[tf,sz] = check_sz_concat(dim,a,b);
+
+if (~tf)
+    % dimensions are consistent if size(a,~dim) == size(b,~dim)
+    throw(casos.package.core.IncompatibleSizesError.concat(a,b));
+
+elseif (isempty(a) && isempty(b))
+    % concatenation of empty polynomials
     c = casos.Sparsity(sz);
     return
 
 elseif isempty(a)
+    % concatenation of b with empty polynomial
     c = b;
     return
 
 elseif isempty(b)
+    % concatenation of a with empty polynomial
     c = a;
     return
 
-elseif (size(a,3-dim) ~= size(b,3-dim))
-    % dimensions are consistent if size(a,~dim) == size(b,~dim)
-    throw(casos.package.core.IncompatibleSizesError.concat(a,b));
+else
 end
 
 % concatenate coefficient matrices

--- a/+casos/@Sparsity/coeff_cat.m
+++ b/+casos/@Sparsity/coeff_cat.m
@@ -9,19 +9,6 @@ function [S,coeffs] = coeff_cat(S1,S2,coeff1,coeff2,dim)
 
 assert(any(dim==[1 2]),'Operating dimension must be either 1 or 2.')
 
-% detect empty polynomials
-if isempty(S1)
-    S = S2;
-    coeffs = coeff2;
-    return
-
-elseif isempty(S2)
-    S = S1;
-    coeffs = coeff1;
-    return
-end
-
-% else
 S = casos.Sparsity;
 
 sza = size(S1);

--- a/+casos/@Sparsity/coeff_power.m
+++ b/+casos/@Sparsity/coeff_power.m
@@ -19,11 +19,18 @@ deg = reshape(deg,1,neb);
 
 if nva == 0 ... % base polynomial is a constant
     || (nta == 1 && nen == 1) % a^n = c*(x^d)^n
+    % find zero degrees
+    in = find(deg == 0); % 1-index
+
     if ~isa(coeffs,'casadi.Sparsity')
         coeffs = coeffs.^deg;
+        % set zero powers to one
+        if ~isempty(in), coeffs(:,in) = 1; end
     else
         % copy pattern
-        coeffs = casadi.Sparsity(coeffs);
+        [ii,jj] = get_triplet(coeffs);
+        % add zero powers (always dense)
+        coeffs = casadi.Sparsity.triplet(nta,neb,[ii zeros(size(in))],[jj in-1]); % 0-index
     end
     if nva > 0
         S.degmat = n.*S.degmat;
@@ -34,28 +41,31 @@ if nva == 0 ... % base polynomial is a constant
 
 elseif is_monom(S)
     % base polynomial is matrix of monomials
-    % match exponents to unique degrees
-    [dd,~,Ideg] = unique(deg);
-    % repeat coefficient sparsity to match exponents
-    S_cfa  = repmat(S.coeffs,nen,1);
-    % match coefficients to corresponding monomials
-    [ia,ja] = get_triplet(S_cfa); % CasADi interface has 0-index
-    is_deg = ceil((ia(:)+1)./nta) == Ideg(ja(:)+1);
-    % select matching coefficients
-    S_cfb = casadi.Sparsity.triplet(size(S_cfa,1),size(S_cfa,2),ia(is_deg),ja(is_deg));
+    % find zero degrees
+    in = find(deg == 0); % 1-index
+    
+    % reorder coefficients to match powers
+    [ii,jj] = get_triplet(S.coeffs); % 0-index
+    % add zero powers (always dense)
+    S_coeffs = casadi.Sparsity.triplet(neb,neb,[jj in-1],[jj in-1]); % 0-index
+
     if ~isa(coeffs,'casadi.Sparsity')
-        % repeat coefficients to match exponents
-        cfa = repmat(coeffs,nen,1);
-        % project onto new sparsity pattern
-        coeffs = project(cfa,S_cfb).^repmat(deg,nta*nen,1);
+        % take power of nonzero coefficients
+        cfa = sum1(coeffs).^deg;
+        % set zero powers to one
+        if ~isempty(in), cfa(in) = 1; end
+        % cast onto reordered sparsity pattern
+        coeffs = sparsity_cast(cfa,S_coeffs);
     else
-        % use new sparsity pattern
-        coeffs = S_cfb;
+        % use coefficient sparsity pattern
+        coeffs = S_coeffs;
     end
-    % repeat degrees to match exponents
-    dga = repmat(S.degmat,nen,1);
-    % multiply degree matrix with (unique) exponents
-    degmat = dga.*reshape(repmat(dd,nta,1),nen*nta,1);
+
+    % reorder degrees to match powers
+    dga = sparse(neb,nva);
+    dga(jj+1,:) = S.degmat(ii+1,:); % 1-index
+    % multiply degree matrix with exponents
+    degmat = dga.*reshape(deg,neb,1);
 
 else
     % compute all (element-wise) powers

--- a/+casos/@Sparsity/mtimes.m
+++ b/+casos/@Sparsity/mtimes.m
@@ -15,7 +15,7 @@ if isscalar(S1) || isscalar(S2)
     S = predict_times(S1,S2);
     return
 
-elseif ~check_sz_mtimes(S1,S2)
+elseif ~check_sz_matrix(S1,S2)
     % dimensions are compatible if size(a,2) == size(b,1)
     throw(casos.package.core.IncompatibleSizesError.matrix(S1,S2));
 end

--- a/+casos/@Sparsity/power.m
+++ b/+casos/@Sparsity/power.m
@@ -5,13 +5,18 @@
 % SPDX-License-Identifier: GPL-3.0-only
 
 function b = power(a,n)
-% Add (join) two polynomial sparsity patterns.
+% Element-wise power of polynomial sparsity pattern.
 
 a = casos.Sparsity(a);
 
 % sparsity pattern and exponent must be of same size
 if ~check_sz_equal(a,n)
     throw(casos.package.core.IncompatibleSizesError.other(a,n));
+
+elseif all(n==0)
+    % power of zero is dense
+    b = casos.Sparsity.dense(size(a));
+    return
 end
 
 % power of coefficient matrix

--- a/+casos/@Sparsity/private/removeZero.m
+++ b/+casos/@Sparsity/private/removeZero.m
@@ -7,8 +7,20 @@
 function [coeffs,degmat,indets] = removeZero(coeffs,degmat,indets)
 % Remove degrees with zero coefficient, update degree matrix, 
 % and remove unused variable.
-
-nel = size(coeffs,2);
+%
+% Arguments:
+%
+%   coeffs                         matrix of which the rows are vec(c_a)
+%   degmat                         matrix of which the rows are [a1 ... aN]
+%   indets                         variables {x1,...,xN} 
+%
+% The number of rows in coeffs and degmat equals the number of terms; after
+% evaluation, this equals the number of terms with nonzero coefficients.
+% The number of columns in coeffs equals the number of elements and remains
+% unchanged.
+% The number of columns in degmat equals the number of indeterminate
+% variables (N); if the indets argument is given, indeterminates with
+% all-zero degrees are removed; otherwise, this remains unchanged.
 
 % remove degrees with zero coefficient
 [coeffs,degmat] = removeCoeffs(coeffs,degmat);
@@ -18,10 +30,9 @@ if nargin > 2
 [degmat, indets] = removeDegVar(degmat, indets);
 end
 
-if isempty(degmat) || length(coeffs) < 1
+if isempty(degmat) || size(coeffs,1) < 1
     % constant polynomial
     coeffs = sum1(coeffs);
-    degmat = sparse(1,0);
 end
 
 end
@@ -35,6 +46,7 @@ function [coeffs,degmat] = removeCoeffs(coeffs,degmat)
 
         % sparsity pattern without all-sparse rows
         [coeffs,nr] = nonzeroPattern(size(coeffs),ii,jj);
+        
     else
         % sparsity pattern of coefficients
         S1 = sparsity(coeffs);
@@ -60,8 +72,10 @@ function [coeffs,degmat] = removeCoeffs(coeffs,degmat)
     end
 
     if isempty(ii)
-        % only zero coefficients
+        % all-sparse coefficients
+        % return row vectors for single (constant) monomial term
         degmat = sparse(1,size(degmat,2));
+
     else
         % remove corresponding degree matrix entries
         degmat = degmat(nr,:);

--- a/+casos/@Sparsity/spy.m
+++ b/+casos/@Sparsity/spy.m
@@ -8,10 +8,12 @@ function spy(obj)
 % Visualize polynomial sparsity pattern.
 
 [degree,L] = get_degree(obj);
+% repeat degree vector to match logical matrix
+degree = repmat(degree,numel(obj),1);
 
 % degrees of each term
 degrees = spalloc(size(L,1),size(L,2),nnz(L));
-degrees(L) = degree;
+degrees(L) = degree(L);
 
 % element-wise max degree
 maxdeg = max(degrees,[],2);
@@ -25,7 +27,8 @@ out = cell(size(obj));
 % set per-element output (sparse zero = ., constant = *, degree = k)
 out(~Lnz) = {'.'};
 out(Lnz & maxdeg == 0) = {'*'};
-out(maxdeg > 0) = compose('%d',full(maxdeg(maxdeg > 0)));
+out(Lnz & maxdeg > 9) = {'x'};
+out(maxdeg > 0 & maxdeg < 10) = compose('%d',full(maxdeg(maxdeg > 0 & maxdeg < 10)));
 
 % print output to command line
 disp(cell2mat(out))

--- a/+casos/PD.m
+++ b/+casos/PD.m
@@ -27,12 +27,12 @@ classdef (InferiorClasses = {?casadi.DM, ?casos.Indeterminates}) ...
 % create from list of monomials 
 % (all non-sparse coefficients equate to 1).
 %
-%   PX(Sparsity,scalar double | DM)
+%   PD(Sparsity,scalar double | DM)
 %
 % create polynomial with constant coefficients 
 % (all non-sparse coefficients equate to the given value).
 %
-%   PX(Sparsity,vector double | DM)
+%   PD(Sparsity,vector double | DM)
 %
 % create polynomial with constant coefficients from vector of nonzeros.
 %

--- a/+casos/PS.m
+++ b/+casos/PS.m
@@ -31,21 +31,21 @@ classdef (InferiorClasses = {?casadi.DM, ?casadi.SX, ?casos.PD, ?casos.Indetermi
 % create from list of monomials 
 % (all non-sparse coefficients equate to 1).
 %
-%   PX(Sparsity,scalar double | DM)
+%   PS(Sparsity,scalar double | DM)
 %
 % create polynomial with constant coefficients 
 % (all non-sparse coefficients equate to the given value).
 %
-%   PX(Sparsity,scalar SX)
+%   PS(Sparsity,scalar SX)
 %
 % create polynomial with symbolic coefficients
 % (all non-sparse coefficients equate to the given expression).
 %
-%   PX(Sparsity,vector double | DM)
+%   PS(Sparsity,vector double | DM)
 %
 % create polynomial with constant coefficients from vector of nonzeros.
 %
-%   PX(Sparsity,vector SX)
+%   PS(Sparsity,vector SX)
 %
 % create polynomial with symbolic coefficients from vector of nonzeros.
 %

--- a/tests/core/TestBinaryPD.m
+++ b/tests/core/TestBinaryPD.m
@@ -189,6 +189,45 @@ methods (Test, ParameterCombination="pairwise", TestTags=["matrix"])
     end
 end
 
+methods (Test, ParameterCombination="pairwise", TestTags=["monomials"])
+    function test_binary_monomials(test_case, op, dim1, dim2)
+        % Test binary operation on monomial matrices.
+        value1 = test_case.values.matrix{4,dim1};
+        value2 = test_case.values.matrix{2,dim2};
+
+        reference = test_case.references.monomials.(op){dim1,dim2};
+
+        switch (op)
+            case {"plus" "minus" "times"}
+                % element-wise addition, subtraction, multiplication
+                test_case.evaluate_binary(op,value1,value2,reference);
+
+            case "ldivide"
+                % left-divide by constant polynomial
+                vars = value1.indeterminates;
+                value1_deg0 = 1+subs(value1,vars,ones(length(vars),1));
+                
+                test_case.evaluate_binary(op,value1_deg0,value2,reference);
+
+            case "rdivide"
+                % right-divide by constant polynomial
+                vars = value2.indeterminates;
+                value2_deg0 = 1+subs(value2,vars,ones(length(vars),1));
+                
+                test_case.evaluate_binary(op,value1,value2_deg0,reference);
+
+            case "power"
+                % element-wise power by degree matrix
+                degs = ceil(2*full(project(value2,restrict_terms(sparsity(value2),0))));
+
+                test_case.evaluate_binary(op,value1,degs,reference);
+
+            otherwise
+                test_case.assertFail(sprintf("Not implemented: %s.",op));
+        end
+    end
+end
+
 methods
     function evaluate_binary(test_case, op, value1, value2, reference)
         % Evaluate binary operation.

--- a/tests/core/TestBinaryPD.m
+++ b/tests/core/TestBinaryPD.m
@@ -13,7 +13,7 @@ properties (SetAccess=protected)
 end
 
 properties (TestParameter)
-    op = {"plus" "minus" "times" "ldivide" "rdivide"};
+    op = {"plus" "minus" "times" "ldivide" "rdivide" "power"};
 
     dim1 = num2cell(1:6);
     dim2 = num2cell(1:6);
@@ -60,6 +60,12 @@ methods (Test, ParameterCombination="pairwise", TestTags="scalar")
                 
                 test_case.evaluate_binary(op,value1,value2_deg0,reference);
 
+            case "power"
+                % element-wise power by degree matrix
+                degs = ceil(2*full(project(value2,restrict_terms(sparsity(value2),0))));
+
+                test_case.evaluate_binary(op,value1,degs,reference);
+
             otherwise
                 test_case.assertFail(sprintf("Not implemented: %s.",op));
         end
@@ -92,6 +98,12 @@ methods (Test, ParameterCombination="pairwise", TestTags=["vector" "inner"])
                 value2_deg0 = 1+subs(value2,vars,ones(length(vars),1));
                 
                 test_case.evaluate_binary(op,value1,value2_deg0,reference);
+
+            case "power"
+                % element-wise power by degree matrix
+                degs = ceil(2*full(project(value2,restrict_terms(sparsity(value2),0))));
+
+                test_case.evaluate_binary(op,value1,degs,reference);
 
             otherwise
                 test_case.assertFail(sprintf("Not implemented: %s.",op));
@@ -126,6 +138,12 @@ methods (Test, ParameterCombination="pairwise", TestTags=["vector" "outer"])
                 
                 test_case.evaluate_binary(op,value1,value2_deg0,reference);
 
+            case "power"
+                % element-wise power by degree matrix
+                degs = ceil(2*full(project(value2,restrict_terms(sparsity(value2),0))));
+
+                test_case.evaluate_binary(op,value1,degs,reference);
+
             otherwise
                 test_case.assertFail(sprintf("Not implemented: %s.",op));
         end
@@ -158,6 +176,12 @@ methods (Test, ParameterCombination="pairwise", TestTags=["matrix"])
                 value2_deg0 = 1+subs(value2,vars,ones(length(vars),1));
                 
                 test_case.evaluate_binary(op,value1,value2_deg0,reference);
+
+            case "power"
+                % element-wise power by degree matrix
+                degs = ceil(2*full(project(value2,restrict_terms(sparsity(value2),0))));
+
+                test_case.evaluate_binary(op,value1,degs,reference);
 
             otherwise
                 test_case.assertFail(sprintf("Not implemented: %s.",op));

--- a/tests/core/TestBinaryPD.m
+++ b/tests/core/TestBinaryPD.m
@@ -172,7 +172,7 @@ methods
                     || (~iscolumn(value1) && ~iscolumn(value2) && size(value1,2) ~= size(value2,2))
             % dimension mismatch
             diagtext = sprintf('Dimension mismatch expected: %s vs. %s.',mat2str(size(value1)),mat2str(size(value2)));
-            test_case.verifyError(@() feval(op,value1,value2),?MException,diagtext);
+            test_case.verifyError(@() feval(op,value1,value2),?casos.package.core.IncompatibleSizesError,diagtext);
             return
         end
 

--- a/tests/core/TestBinaryPD.m
+++ b/tests/core/TestBinaryPD.m
@@ -243,7 +243,7 @@ methods
         actual = feval(op,value1,value2);
 
         % perform assertion
-        test_case.verifyEqualPolynomial(actual,reference,"RelTol",1e-15);
+        test_case.verifyEqualPolynomial(actual,reference,"RelTol",1e-14);
     end
 end
 

--- a/tests/core/TestBinaryPS.m
+++ b/tests/core/TestBinaryPS.m
@@ -180,7 +180,7 @@ methods
                     || (~iscolumn(value1) && ~iscolumn(value2) && size(value1,2) ~= size(value2,2))
             % dimension mismatch
             diagtext = sprintf('Dimension mismatch expected: %s vs. %s.',mat2str(size(value1)),mat2str(size(value2)));
-            test_case.verifyError(@() feval(op,p1,p2),?MException,diagtext);
+            test_case.verifyError(@() feval(op,p1,p2),?casos.package.core.IncompatibleSizesError,diagtext);
             return
         end
 

--- a/tests/core/TestBinaryPS.m
+++ b/tests/core/TestBinaryPS.m
@@ -13,7 +13,7 @@ properties (SetAccess=protected)
 end
 
 properties (TestParameter)
-    op = {"plus" "minus" "times" "ldivide" "rdivide"};
+    op = {"plus" "minus" "times" "ldivide" "rdivide" "power"};
     symb1 = {false true};
     symb2 = {false true};
 
@@ -62,6 +62,12 @@ methods (Test, ParameterCombination="pairwise", TestTags="scalar")
                 
                 test_case.evaluate_binary(op,symb1,symb2,value1,value2_deg0,reference);
 
+            case "power"
+                % element-wise power by degree matrix
+                degs = ceil(2*full(project(value2,restrict_terms(sparsity(value2),0))));
+
+                test_case.evaluate_binary(op,symb1,symb2,value1,degs,reference);
+
             otherwise
                 test_case.assertFail(sprintf("Not implemented: %s.",op));
         end
@@ -94,6 +100,12 @@ methods (Test, ParameterCombination="pairwise", TestTags=["vector" "inner"])
                 value2_deg0 = 1+subs(value2,vars,ones(length(vars),1));
                 
                 test_case.evaluate_binary(op,symb1,symb2,value1,value2_deg0,reference);
+
+            case "power"
+                % element-wise power by degree matrix
+                degs = ceil(2*full(project(value2,restrict_terms(sparsity(value2),0))));
+
+                test_case.evaluate_binary(op,symb1,symb2,value1,degs,reference);
 
             otherwise
                 test_case.assertFail(sprintf("Not implemented: %s.",op));
@@ -128,6 +140,12 @@ methods (Test, ParameterCombination="pairwise", TestTags=["vector" "outer"])
                 
                 test_case.evaluate_binary(op,symb1,symb2,value1,value2_deg0,reference);
 
+            case "power"
+                % element-wise power by degree matrix
+                degs = ceil(2*full(project(value2,restrict_terms(sparsity(value2),0))));
+
+                test_case.evaluate_binary(op,symb1,symb2,value1,degs,reference);
+
             otherwise
                 test_case.assertFail(sprintf("Not implemented: %s.",op));
         end
@@ -161,6 +179,12 @@ methods (Test, ParameterCombination="pairwise", TestTags=["matrix"])
                 
                 test_case.evaluate_binary(op,symb1,symb2,value1,value2_deg0,reference);
 
+            case "power"
+                % element-wise power by degree matrix
+                degs = ceil(2*full(project(value2,restrict_terms(sparsity(value2),0))));
+
+                test_case.evaluate_binary(op,symb1,symb2,value1,degs,reference);
+
             otherwise
                 test_case.assertFail(sprintf("Not implemented: %s.",op));
         end
@@ -170,11 +194,23 @@ end
 methods
     function evaluate_binary(test_case, op, symb1, symb2, value1, value2, reference)
         % Evaluate binary operation.
-        test_case.assumeTrue(symb1 || symb2, "Operands not symbolic.");
+        switch (op)
+            case "power"
+                % element-wise power with degree matrix
+                test_case.assumeTrue(symb1 && symb2, "Operands not symbolic.");
         
-        % symbolic polynomials
-        [p1,symbol1,argument1] = test_case.get_operand(symb1,value1);
-        [p2,symbol2,argument2] = test_case.get_operand(symb2,value2);
+                % symbolic polynomials
+                [p1,symbol1,argument1] = test_case.get_operand(symb1,value1);
+                [p2,symbol2,argument2] = deal(value2,{},{});
+
+            otherwise
+                % all other operations
+                test_case.assumeTrue(symb1 || symb2, "Operands not symbolic.");
+                
+                % symbolic polynomials
+                [p1,symbol1,argument1] = test_case.get_operand(symb1,value1);
+                [p2,symbol2,argument2] = test_case.get_operand(symb2,value2);
+        end
 
         if (~isrow(value1) && ~isrow(value2) && size(value1,1) ~= size(value2,1)) ...
                     || (~iscolumn(value1) && ~iscolumn(value2) && size(value1,2) ~= size(value2,2))

--- a/tests/core/TestBinaryPS.m
+++ b/tests/core/TestBinaryPS.m
@@ -228,7 +228,7 @@ methods
         actual = f(argument1{:},argument2{:});
 
         % perform assertion
-        test_case.verifyEqualPolynomial(actual,reference,"RelTol",1e-15);
+        test_case.verifyEqualPolynomial(actual,reference,"RelTol",1e-14);
     end
 end
 

--- a/tests/core/TestConcatPD.m
+++ b/tests/core/TestConcatPD.m
@@ -159,8 +159,8 @@ methods
         if ~isempty(value1) && ~isempty(value2) && size(value1,1) ~= size(value2,1)
             % first dimension mismatch
             diagtext = sprintf('First dimension mismatch expected: %d vs. %d.',size(value1,1),size(value2,1));
-            test_case.verifyError(@() horzcat(value1,value2),?MException,diagtext);
-            test_case.verifyError(@() cat(2,value1,value2),?MException,diagtext);
+            test_case.verifyError(@() horzcat(value1,value2),?casos.package.core.IncompatibleSizesError,diagtext);
+            test_case.verifyError(@() cat(2,value1,value2),?casos.package.core.IncompatibleSizesError,diagtext);
             return
         end
 
@@ -177,8 +177,8 @@ methods
         if ~isempty(value1) && ~isempty(value2) && size(value1,2) ~= size(value2,2)
             % second dimension mismatch
             diagtext = sprintf('Second dimension mismatch expected: %d vs. %d.',size(value1,2),size(value2,2));
-            test_case.verifyError(@() vertcat(value1,value2),?MException,diagtext);
-            test_case.verifyError(@() cat(1,value1,value2),?MException,diagtext);
+            test_case.verifyError(@() vertcat(value1,value2),?casos.package.core.IncompatibleSizesError,diagtext);
+            test_case.verifyError(@() cat(1,value1,value2),?casos.package.core.IncompatibleSizesError,diagtext);
             return
         end
 

--- a/tests/core/TestConcatPS.m
+++ b/tests/core/TestConcatPS.m
@@ -176,8 +176,8 @@ methods
         if ~isempty(value1) && ~isempty(value2) && size(value1,1) ~= size(value2,1)
             % first dimension mismatch
             diagtext = sprintf('First dimension mismatch expected: %d vs. %d.',size(value1,1),size(value2,1));
-            test_case.verifyError(@() horzcat(p1,p2),?MException,diagtext);
-            test_case.verifyError(@() cat(2,p1,p2),?MException,diagtext);
+            test_case.verifyError(@() horzcat(p1,p2),?casos.package.core.IncompatibleSizesError,diagtext);
+            test_case.verifyError(@() cat(2,p1,p2),?casos.package.core.IncompatibleSizesError,diagtext);
             return
         end
 
@@ -207,8 +207,8 @@ methods
         if ~isempty(value1) && ~isempty(value2) && size(value1,2) ~= size(value2,2)
             % second dimension mismatch
             diagtext = sprintf('Second dimension mismatch expected: %d vs. %d.',size(value1,2),size(value2,2));
-            test_case.verifyError(@() vertcat(p1,p2),?MException,diagtext);
-            test_case.verifyError(@() cat(1,p1,p2),?MException,diagtext);
+            test_case.verifyError(@() vertcat(p1,p2),?casos.package.core.IncompatibleSizesError,diagtext);
+            test_case.verifyError(@() cat(1,p1,p2),?casos.package.core.IncompatibleSizesError,diagtext);
             return
         end
 

--- a/tests/core/TestDotPD.m
+++ b/tests/core/TestDotPD.m
@@ -61,7 +61,7 @@ methods
         if ~isequal(size(value1), size(value2))
             % size mismatch
             diagtext = sprintf('Dimension mismatch expected: %s vs. %s.',mat2str(size(value1)),mat2str(size(value2)));
-            test_case.verifyError(@() dot(value1,value2),?MException,diagtext);
+            test_case.verifyError(@() dot(value1,value2),?casos.package.core.IncompatibleSizesError,diagtext);
             return
         end
 

--- a/tests/core/TestDotPS.m
+++ b/tests/core/TestDotPS.m
@@ -70,7 +70,7 @@ methods
         if ~isequal(size(value1), size(value2))
             % size mismatch
             diagtext = sprintf('Dimension mismatch expected: %s vs. %s.',mat2str(size(value1)),mat2str(size(value2)));
-            test_case.verifyError(@() dot(p1,p2),?MException,diagtext);
+            test_case.verifyError(@() dot(p1,p2),?casos.package.core.IncompatibleSizesError,diagtext);
             return
         end
 

--- a/tests/core/TestIsLinear.m
+++ b/tests/core/TestIsLinear.m
@@ -159,7 +159,7 @@ methods
         % perform assertions
         test_case.verifyReturnsTrue(actual1);
 
-        if (~symb1) && ~isempty(q)
+        if (~symb1) && (nnz(p) > 0)
             diagtext = "Expected exception for nonsymbolic variable.";
             test_case.verifyError(actual2,?MException,diagtext);
         else
@@ -190,10 +190,10 @@ methods
 
         test_case.verifyReturnsTrue(actual1);
 
-        if (~symb1) && ~isempty(p)
+        if (~symb1) && (nnz(p) > 0)
             diagtext = "Expected exception for nonsymbolic variable.";
             test_case.verifyError(actual2,?MException,diagtext);
-        elseif isempty(p) || ismember(op2,["plus" "minus"])
+        elseif isempty(r) || (nnz(p) == 0) || ismember(op2,["plus" "minus"])
             test_case.verifyReturnsTrue(actual2);
         else
             test_case.verifyReturnsTrue(actual3);
@@ -223,13 +223,13 @@ methods
         % perform assertions
         test_case.verifyReturnsTrue(actual1);
 
-        if (~symb1) && ~isempty(p)
+        if (~symb1) && (nnz(p) > 0)
             diagtext = "Expected exception for nonsymbolic variable.";
             test_case.verifyError(actual2,?MException,diagtext);
         else
             test_case.verifyReturnsTrue(actual2);
         end
-        if (~symb2) && ~isempty(q)
+        if (~symb2) && (nnz(q) > 0)
             diagtext = "Expected exception for nonsymbolic variable.";
             test_case.verifyError(actual3,?MException,diagtext);
         else

--- a/tests/core/TestMtimesPD.m
+++ b/tests/core/TestMtimesPD.m
@@ -145,7 +145,11 @@ end
 methods
     function evaluate_mtimes(test_case, op, value1, value2, reference)
         % Evaluate matrix multiplication operation.
-        if strcmp(op,"mtimes") && (size(value1,2) ~= size(value2,1))
+        if strcmp(op,"mtimes") && ~any([
+                isscalar(value1)
+                isscalar(value2)
+                size(value1,2) == size(value2,1)
+            ])
             % inner dimension mismatch
             diagtext = sprintf('Inner dimension mismatch expected: %d vs. %d.',size(value1,2),size(value2,1));
             test_case.verifyError(@() feval(op,value1,value2),?MException,diagtext);
@@ -153,11 +157,10 @@ methods
         end
 
         % else
-        actual = mtimes(value1,value2);
+        actual = feval(op,value1,value2);
 
         % perform assertion
         test_case.verifyEqualPolynomial(actual,reference,"RelTol",1e-15);
-
     end
 end
 

--- a/tests/core/TestMtimesPD.m
+++ b/tests/core/TestMtimesPD.m
@@ -152,7 +152,7 @@ methods
             ])
             % inner dimension mismatch
             diagtext = sprintf('Inner dimension mismatch expected: %d vs. %d.',size(value1,2),size(value2,1));
-            test_case.verifyError(@() feval(op,value1,value2),?MException,diagtext);
+            test_case.verifyError(@() feval(op,value1,value2),?casos.package.core.IncompatibleSizesError,diagtext);
             return
         end
 

--- a/tests/core/TestMtimesPD.m
+++ b/tests/core/TestMtimesPD.m
@@ -51,14 +51,14 @@ methods (Test, ParameterCombination="pairwise", TestTags="scalar")
             case {"mldivide"}
                 % matrix left-divide
                 vars = value1.indeterminates;
-                value1_deg0 = subs(value1,vars,ones(length(vars),1));
+                value1_deg0 = 1+subs(value1,vars,ones(length(vars),1));
         
                 test_case.evaluate_mtimes(op,value1_deg0,value2,reference);
 
             case {"mrdivide"}
                 % matrix right-divide
                 vars = value2.indeterminates;
-                value2_deg0 = subs(value2,vars,ones(length(vars),1));
+                value2_deg0 = 1+subs(value2,vars,ones(length(vars),1));
         
                 test_case.evaluate_mtimes(op,value1,value2_deg0,reference);
         end

--- a/tests/core/TestMtimesPS.m
+++ b/tests/core/TestMtimesPS.m
@@ -160,7 +160,11 @@ methods
         [p1,symbol1,argument1] = test_case.get_operand(symb1,value1);
         [p2,symbol2,argument2] = test_case.get_operand(symb2,value2);
 
-        if strcmp(op,"mtimes") && (size(value1,2) ~= size(value2,1))
+        if strcmp(op,"mtimes") && ~any([
+                isscalar(value1)
+                isscalar(value2)
+                size(value1,2) == size(value2,1)
+            ])
             % inner dimension mismatch for matrix multiplication
             diagtext = sprintf('Inner dimension mismatch expected: %d vs. %d.',size(value1,2),size(value2,1));
             test_case.verifyError(@() feval(op,p1,p2),?MException,diagtext);

--- a/tests/core/TestMtimesPS.m
+++ b/tests/core/TestMtimesPS.m
@@ -167,7 +167,7 @@ methods
             ])
             % inner dimension mismatch for matrix multiplication
             diagtext = sprintf('Inner dimension mismatch expected: %d vs. %d.',size(value1,2),size(value2,1));
-            test_case.verifyError(@() feval(op,p1,p2),?MException,diagtext);
+            test_case.verifyError(@() feval(op,p1,p2),?casos.package.core.IncompatibleSizesError,diagtext);
             return
         end
 

--- a/tests/core/TestMtimesPS.m
+++ b/tests/core/TestMtimesPS.m
@@ -53,14 +53,14 @@ methods (Test, ParameterCombination="pairwise", TestTags="scalar")
             case {"mldivide"}
                 % matrix left-divide
                 vars = value1.indeterminates;
-                value1_deg0 = subs(value1,vars,ones(length(vars),1));
+                value1_deg0 = 1+subs(value1,vars,ones(length(vars),1));
         
                 test_case.evaluate_mtimes(op,symb1,symb2,value1_deg0,value2,reference);
 
             case {"mrdivide"}
                 % matrix right-divide
                 vars = value2.indeterminates;
-                value2_deg0 = subs(value2,vars,ones(length(vars),1));
+                value2_deg0 = 1+subs(value2,vars,ones(length(vars),1));
         
                 test_case.evaluate_mtimes(op,symb1,symb2,value1,value2_deg0,reference);
         end

--- a/tests/core/TestPoly2BasisPD.m
+++ b/tests/core/TestPoly2BasisPD.m
@@ -35,7 +35,7 @@ methods (Test, ParameterCombination="pairwise", TestTags="scalar")
     function test_poly2basis_scalar(test_case, arg1, arg2)
         % Test poly2basis operation.
         value = test_case.values.scalar{1,arg1};
-        basis = sparsity(test_case.values.scalar{2,arg2});
+        basis = sparsity(densify(test_case.values.scalar{2,arg2})); % project onto dense basis
 
         reference = test_case.references.scalar{arg1,arg2};
 
@@ -47,7 +47,7 @@ methods (Test, ParameterCombination="pairwise", TestTags=["vector" "column"])
     function test_poly2basis_column(test_case, dim1, dim2)
         % Test poly2basis operation on column vectors.
         value = test_case.values.vector{1,dim1};
-        basis = sparsity(test_case.values.vector{2,dim2});
+        basis = sparsity(densify(test_case.values.vector{2,dim2})); % project onto dense basis
         
         reference = test_case.references.column{dim1,dim2};
 
@@ -59,7 +59,7 @@ methods (Test, ParameterCombination="pairwise", TestTags=["vector" "row"])
     function test_poly2basis_row(test_case, dim1, dim2)
         % Test poly2basis operation on row vectors.
         value = test_case.values.vector{1,dim1}';
-        basis = sparsity(test_case.values.vector{2,dim2}');
+        basis = sparsity(densify(test_case.values.vector{2,dim2}')); % project onto dense basis
         
         reference = test_case.references.row{dim1,dim2};
 
@@ -71,7 +71,7 @@ methods (Test, ParameterCombination="pairwise", TestTags="matrix")
     function test_poly2basis_matrix(test_case, dim1, dim2)
         % Test poly2basis operation on matrices.
         value = test_case.values.matrix{1,dim1};
-        basis = sparsity(test_case.values.matrix{2,dim2});
+        basis = sparsity(densify(test_case.values.matrix{2,dim2})); % project onto dense basis
         
         reference = test_case.references.matrix{dim1,dim2};
 

--- a/tests/core/TestPoly2BasisPD.m
+++ b/tests/core/TestPoly2BasisPD.m
@@ -85,7 +85,7 @@ methods
         if ~isequal(size(value),size(basis))
             % size mismatch
             diagtext = sprintf('Dimension mismatch expected: %s vs. %s.',mat2str(size(value)),mat2str(size(basis)));
-            test_case.verifyError(@() poly2basis(value,basis),?MException,diagtext);
+            test_case.verifyError(@() poly2basis(value,basis),?casos.package.core.IncompatibleSizesError,diagtext);
             return
         end
 

--- a/tests/core/TestPoly2BasisPD.m
+++ b/tests/core/TestPoly2BasisPD.m
@@ -82,7 +82,7 @@ end
 methods
     function evaluate_poly2basis(test_case, value, basis, reference)
         % Evaluate poly2basis operation.
-        if ~isequal(size(value),size(basis))
+        if ~isscalar(value) && ~isequal(size(value),size(basis))
             % size mismatch
             diagtext = sprintf('Dimension mismatch expected: %s vs. %s.',mat2str(size(value)),mat2str(size(basis)));
             test_case.verifyError(@() poly2basis(value,basis),?casos.package.core.IncompatibleSizesError,diagtext);

--- a/tests/core/TestPoly2BasisPD.m
+++ b/tests/core/TestPoly2BasisPD.m
@@ -82,7 +82,7 @@ end
 methods
     function evaluate_poly2basis(test_case, value, basis, reference)
         % Evaluate poly2basis operation.
-        if ~isscalar(value) && ~isequal(size(value),size(basis))
+        if ~isscalar(value) && ~(isequal(size(value),[0 0]) && isempty(basis)) && ~isequal(size(value),size(basis))
             % size mismatch
             diagtext = sprintf('Dimension mismatch expected: %s vs. %s.',mat2str(size(value)),mat2str(size(basis)));
             test_case.verifyError(@() poly2basis(value,basis),?casos.package.core.IncompatibleSizesError,diagtext);

--- a/tests/core/TestPoly2BasisPS.m
+++ b/tests/core/TestPoly2BasisPS.m
@@ -86,7 +86,7 @@ methods
         % symbolic polynomial
         [p,symbol,argument] = test_case.get_operand(true,value);
 
-        if ~isequal(size(value),size(basis))
+        if ~isscalar(value) && ~isequal(size(value),size(basis))
             % size mismatch
             diagtext = sprintf('Dimension mismatch expected: %s vs. %s.',mat2str(size(value)),mat2str(size(basis)));
             test_case.verifyError(@() poly2basis(p,basis),?casos.package.core.IncompatibleSizesError,diagtext);

--- a/tests/core/TestPoly2BasisPS.m
+++ b/tests/core/TestPoly2BasisPS.m
@@ -35,7 +35,7 @@ methods (Test, ParameterCombination="pairwise", TestTags="scalar")
     function test_poly2basis_scalar(test_case, arg1, arg2)
         % Test poly2basis operation.
         value = test_case.values.scalar{1,arg1};
-        basis = sparsity(test_case.values.scalar{2,arg2});
+        basis = sparsity(densify(test_case.values.scalar{2,arg2})); % project onto dense basis
 
         reference = test_case.references.scalar{arg1,arg2};
 
@@ -47,7 +47,7 @@ methods (Test, ParameterCombination="pairwise", TestTags=["vector" "column"])
     function test_poly2basis_column(test_case, dim1, dim2)
         % Test poly2basis operation on column vectors.
         value = test_case.values.vector{1,dim1};
-        basis = sparsity(test_case.values.vector{2,dim2});
+        basis = sparsity(densify(test_case.values.vector{2,dim2})); % project onto dense basis
         
         reference = test_case.references.column{dim1,dim2};
 
@@ -59,7 +59,7 @@ methods (Test, ParameterCombination="pairwise", TestTags=["vector" "row"])
     function test_poly2basis_row(test_case, dim1, dim2)
         % Test poly2basis operation on row vectors.
         value = test_case.values.vector{1,dim1}';
-        basis = sparsity(test_case.values.vector{2,dim2}');
+        basis = sparsity(densify(test_case.values.vector{2,dim2}')); % project onto dense basis
         
         reference = test_case.references.row{dim1,dim2};
 
@@ -71,7 +71,7 @@ methods (Test, ParameterCombination="pairwise", TestTags="matrix")
     function test_poly2basis_matrix(test_case, dim1, dim2)
         % Test poly2basis operation on matrices.
         value = test_case.values.matrix{1,dim1};
-        basis = sparsity(test_case.values.matrix{2,dim2});
+        basis = sparsity(densify(test_case.values.matrix{2,dim2})); % project onto dense basis
         
         reference = test_case.references.matrix{dim1,dim2};
 

--- a/tests/core/TestPoly2BasisPS.m
+++ b/tests/core/TestPoly2BasisPS.m
@@ -89,7 +89,7 @@ methods
         if ~isequal(size(value),size(basis))
             % size mismatch
             diagtext = sprintf('Dimension mismatch expected: %s vs. %s.',mat2str(size(value)),mat2str(size(basis)));
-            test_case.verifyError(@() poly2basis(p,basis),?MException,diagtext);
+            test_case.verifyError(@() poly2basis(p,basis),?casos.package.core.IncompatibleSizesError,diagtext);
             return
         end
 

--- a/tests/core/TestPoly2BasisPS.m
+++ b/tests/core/TestPoly2BasisPS.m
@@ -86,7 +86,7 @@ methods
         % symbolic polynomial
         [p,symbol,argument] = test_case.get_operand(true,value);
 
-        if ~isscalar(value) && ~isequal(size(value),size(basis))
+        if ~isscalar(value) && ~(isequal(size(value),[0 0]) && isempty(basis)) && ~isequal(size(value),size(basis))
             % size mismatch
             diagtext = sprintf('Dimension mismatch expected: %s vs. %s.',mat2str(size(value)),mat2str(size(basis)));
             test_case.verifyError(@() poly2basis(p,basis),?casos.package.core.IncompatibleSizesError,diagtext);

--- a/tests/core/TestProjectPD.m
+++ b/tests/core/TestProjectPD.m
@@ -85,7 +85,7 @@ methods
         if ~isequal(size(value),size(basis))
             % size mismatch
             diagtext = sprintf('Dimension mismatch expected: %s vs. %s.',mat2str(size(value)),mat2str(size(basis)));
-            test_case.verifyError(@() project(value,basis),?MException,diagtext);
+            test_case.verifyError(@() project(value,basis),?casos.package.core.IncompatibleSizesError,diagtext);
             return
         end
 

--- a/tests/core/TestProjectPD.m
+++ b/tests/core/TestProjectPD.m
@@ -35,7 +35,7 @@ methods (Test, ParameterCombination="pairwise", TestTags="scalar")
     function test_project_scalar(test_case, arg1, arg2)
         % Test project operation.
         value = test_case.values.scalar{1,arg1};
-        basis = sparsity(test_case.values.scalar{2,arg2});
+        basis = sparsity(densify(test_case.values.scalar{2,arg2})); % project onto dense basis
 
         reference = test_case.references.scalar{arg1,arg2};
 
@@ -47,7 +47,7 @@ methods (Test, ParameterCombination="pairwise", TestTags=["vector" "column"])
     function test_project_column(test_case, dim1, dim2)
         % Test project operation on column vectors.
         value = test_case.values.vector{1,dim1};
-        basis = sparsity(test_case.values.vector{2,dim2});
+        basis = sparsity(densify(test_case.values.vector{2,dim2})); % project onto dense basis
         
         reference = test_case.references.column{dim1,dim2};
 
@@ -59,7 +59,7 @@ methods (Test, ParameterCombination="pairwise", TestTags=["vector" "row"])
     function test_project_row(test_case, dim1, dim2)
         % Test project operation on row vectors.
         value = test_case.values.vector{1,dim1}';
-        basis = sparsity(test_case.values.vector{2,dim2}');
+        basis = sparsity(densify(test_case.values.vector{2,dim2}')); % project onto dense basis
         
         reference = test_case.references.row{dim1,dim2};
 
@@ -71,7 +71,7 @@ methods (Test, ParameterCombination="pairwise", TestTags="matrix")
     function test_project_matrix(test_case, dim1, dim2)
         % Test project operation on matrices.
         value = test_case.values.matrix{1,dim1};
-        basis = sparsity(test_case.values.matrix{2,dim2});
+        basis = sparsity(densify(test_case.values.matrix{2,dim2})); % project onto dense basis
         
         reference = test_case.references.matrix{dim1,dim2};
 

--- a/tests/core/TestProjectPS.m
+++ b/tests/core/TestProjectPS.m
@@ -35,7 +35,7 @@ methods (Test, ParameterCombination="pairwise", TestTags="scalar")
     function test_project_scalar(test_case, arg1, arg2)
         % Test project operation.
         value = test_case.values.scalar{1,arg1};
-        basis = sparsity(test_case.values.scalar{2,arg2});
+        basis = sparsity(densify(test_case.values.scalar{2,arg2})); % project onto dense basis
 
         reference = test_case.references.scalar{arg1,arg2};
 
@@ -47,7 +47,7 @@ methods (Test, ParameterCombination="pairwise", TestTags=["vector" "column"])
     function test_project_column(test_case, dim1, dim2)
         % Test project operation on column vectors.
         value = test_case.values.vector{1,dim1};
-        basis = sparsity(test_case.values.vector{2,dim2});
+        basis = sparsity(densify(test_case.values.vector{2,dim2})); % project onto dense basis
         
         reference = test_case.references.column{dim1,dim2};
 
@@ -59,7 +59,7 @@ methods (Test, ParameterCombination="pairwise", TestTags=["vector" "row"])
     function test_project_row(test_case, dim1, dim2)
         % Test project operation on row vectors.
         value = test_case.values.vector{1,dim1}';
-        basis = sparsity(test_case.values.vector{2,dim2}');
+        basis = sparsity(densify(test_case.values.vector{2,dim2}')); % project onto dense basis
         
         reference = test_case.references.row{dim1,dim2};
 
@@ -71,7 +71,7 @@ methods (Test, ParameterCombination="pairwise", TestTags="matrix")
     function test_project_matrix(test_case, dim1, dim2)
         % Test project operation on matrices.
         value = test_case.values.matrix{1,dim1};
-        basis = sparsity(test_case.values.matrix{2,dim2});
+        basis = sparsity(densify(test_case.values.matrix{2,dim2})); % project onto dense basis
         
         reference = test_case.references.matrix{dim1,dim2};
 

--- a/tests/core/TestProjectPS.m
+++ b/tests/core/TestProjectPS.m
@@ -89,7 +89,7 @@ methods
         if ~isequal(size(value),size(basis))
             % size mismatch
             diagtext = sprintf('Dimension mismatch expected: %s vs. %s.',mat2str(size(value)),mat2str(size(basis)));
-            test_case.verifyError(@() project(p,basis),?MException,diagtext);
+            test_case.verifyError(@() project(p,basis),?casos.package.core.IncompatibleSizesError,diagtext);
             return
         end
 

--- a/tests/core/TestRemoveCoeffs.m
+++ b/tests/core/TestRemoveCoeffs.m
@@ -80,7 +80,7 @@ end
 methods
     function evaluate_remove_coeffs(test_case, decade, value1, value2, reference)
         % Evaluate remove_coeffs operation.
-        tol = prctile([0; full(poly2basis(value2))],10*decade);
+        tol = prctile([0; full(poly2basis(densify(value2)))],10*decade); % project onto dense basis
         actual = remove_coeffs(value1,tol);
 
         % perform assertion

--- a/tests/core/TestSubsPD.m
+++ b/tests/core/TestSubsPD.m
@@ -40,6 +40,10 @@ methods (Test, ParameterCombination="pairwise", TestTags="scalar")
         value1 = test_case.values.scalar{1,arg};
         value2 = test_case.values.scalar{2,arg};
 
+        % reduce order of polynomials
+        value1 = project(value1,restrict_terms(sparsity(value1),0:4));
+        value2 = project(value2,restrict_terms(sparsity(value2),0:4));
+
         reference = test_case.references.scalar.single{arg,ivar};
 
         test_case.evaluate_subs_single(ivar,value1,value2,reference);
@@ -49,6 +53,10 @@ methods (Test, ParameterCombination="pairwise", TestTags="scalar")
         % Test substitution of multiple variables.
         value1 = test_case.values.scalar{2,arg};
         value2 = test_case.values.vector{2,value1.nvars+1};
+
+        % reduce order of polynomials
+        value1 = project(value1,restrict_terms(sparsity(value1),0:4));
+        value2 = project(value2,restrict_terms(sparsity(value2),0:4));
 
         reference = test_case.references.scalar.multiple{arg,ivar};
 
@@ -62,6 +70,10 @@ methods (Test, ParameterCombination="pairwise", TestTags=["vector" "column"])
         value1 = test_case.values.vector{1,dim};
         value2 = test_case.values.scalar{1,dim};
 
+        % reduce order of polynomials
+        value1 = project(value1,restrict_terms(sparsity(value1),0:4));
+        value2 = project(value2,restrict_terms(sparsity(value2),0:4));
+
         reference = test_case.references.column.single{dim,ivar};
 
         test_case.evaluate_subs_single(ivar,value1,value2,reference);
@@ -71,6 +83,10 @@ methods (Test, ParameterCombination="pairwise", TestTags=["vector" "column"])
         % Test substitution of multiple variables in a column vector.
         value1 = test_case.values.vector{2,dim};
         value2 = test_case.values.vector{1,value1.nvars+1};
+
+        % reduce order of polynomials
+        value1 = project(value1,restrict_terms(sparsity(value1),0:4));
+        value2 = project(value2,restrict_terms(sparsity(value2),0:4));
 
         reference = test_case.references.column.multiple{dim,ivar};
 
@@ -84,6 +100,10 @@ methods (Test, ParameterCombination="pairwise", TestTags=["vector" "row"])
         value1 = test_case.values.vector{2,dim}';
         value2 = test_case.values.scalar{2,dim};
 
+        % reduce order of polynomials
+        value1 = project(value1,restrict_terms(sparsity(value1),0:4));
+        value2 = project(value2,restrict_terms(sparsity(value2),0:4));
+
         reference = test_case.references.row.single{dim,ivar};
 
         test_case.evaluate_subs_single(ivar,value1,value2,reference);
@@ -93,6 +113,10 @@ methods (Test, ParameterCombination="pairwise", TestTags=["vector" "row"])
         % Test substitution of multiple variables in a row vector.
         value1 = test_case.values.vector{1,dim}';
         value2 = test_case.values.vector{2,value1.nvars+1};
+
+        % reduce order of polynomials
+        value1 = project(value1,restrict_terms(sparsity(value1),0:4));
+        value2 = project(value2,restrict_terms(sparsity(value2),0:4));
 
         reference = test_case.references.row.multiple{dim,ivar};
 
@@ -106,6 +130,10 @@ methods (Test, ParameterCombination="pairwise", TestTags="matrix")
         value1 = test_case.values.matrix{2,dim};
         value2 = test_case.values.scalar{1,dim};
 
+        % reduce order of polynomials
+        value1 = project(value1,restrict_terms(sparsity(value1),0:4));
+        value2 = project(value2,restrict_terms(sparsity(value2),0:4));
+
         reference = test_case.references.matrix.single{dim,ivar};
 
         test_case.evaluate_subs_single(ivar,value1,value2,reference);
@@ -115,6 +143,10 @@ methods (Test, ParameterCombination="pairwise", TestTags="matrix")
         % Test substitution of multiple variables in a column vector.
         value1 = test_case.values.matrix{1,dim};
         value2 = test_case.values.vector{1,value1.nvars+1};
+
+        % reduce order of polynomials
+        value1 = project(value1,restrict_terms(sparsity(value1),0:4));
+        value2 = project(value2,restrict_terms(sparsity(value2),0:4));
 
         reference = test_case.references.matrix.multiple{dim,ivar};
 

--- a/tests/core/TestSubsPS.m
+++ b/tests/core/TestSubsPS.m
@@ -42,6 +42,10 @@ methods (Test, ParameterCombination="pairwise", TestTags="scalar")
         value1 = test_case.values.scalar{1,arg};
         value2 = test_case.values.scalar{2,arg};
 
+        % reduce order of polynomials
+        value1 = project(value1,restrict_terms(sparsity(value1),0:4));
+        value2 = project(value2,restrict_terms(sparsity(value2),0:4));
+
         reference = test_case.references.scalar.single{arg,ivar};
 
         test_case.evaluate_subs_single(symb1,symb2,ivar,value1,value2,reference);
@@ -51,6 +55,10 @@ methods (Test, ParameterCombination="pairwise", TestTags="scalar")
         % Test substitution of multiple variables.
         value1 = test_case.values.scalar{2,arg};
         value2 = test_case.values.vector{2,value1.nvars+1};
+
+        % reduce order of polynomials
+        value1 = project(value1,restrict_terms(sparsity(value1),0:4));
+        value2 = project(value2,restrict_terms(sparsity(value2),0:4));
 
         reference = test_case.references.scalar.multiple{arg,ivar};
 
@@ -64,6 +72,10 @@ methods (Test, ParameterCombination="pairwise", TestTags=["vector" "column"])
         value1 = test_case.values.vector{1,dim};
         value2 = test_case.values.scalar{1,dim};
 
+        % reduce order of polynomials
+        value1 = project(value1,restrict_terms(sparsity(value1),0:4));
+        value2 = project(value2,restrict_terms(sparsity(value2),0:4));
+
         reference = test_case.references.column.single{dim,ivar};
 
         test_case.evaluate_subs_single(symb1,symb2,ivar,value1,value2,reference);
@@ -73,6 +85,10 @@ methods (Test, ParameterCombination="pairwise", TestTags=["vector" "column"])
         % Test substitution of multiple variables in a column vector.
         value1 = test_case.values.vector{2,dim};
         value2 = test_case.values.vector{1,value1.nvars+1};
+
+        % reduce order of polynomials
+        value1 = project(value1,restrict_terms(sparsity(value1),0:4));
+        value2 = project(value2,restrict_terms(sparsity(value2),0:4));
 
         reference = test_case.references.column.multiple{dim,ivar};
 
@@ -86,6 +102,10 @@ methods (Test, ParameterCombination="pairwise", TestTags=["vector" "row"])
         value1 = test_case.values.vector{2,dim}';
         value2 = test_case.values.scalar{2,dim};
 
+        % reduce order of polynomials
+        value1 = project(value1,restrict_terms(sparsity(value1),0:4));
+        value2 = project(value2,restrict_terms(sparsity(value2),0:4));
+
         reference = test_case.references.row.single{dim,ivar};
 
         test_case.evaluate_subs_single(symb1,symb2,ivar,value1,value2,reference);
@@ -95,6 +115,10 @@ methods (Test, ParameterCombination="pairwise", TestTags=["vector" "row"])
         % Test substitution of multiple variables in a row vector.
         value1 = test_case.values.vector{1,dim}';
         value2 = test_case.values.vector{2,value1.nvars+1};
+
+        % reduce order of polynomials
+        value1 = project(value1,restrict_terms(sparsity(value1),0:4));
+        value2 = project(value2,restrict_terms(sparsity(value2),0:4));
 
         reference = test_case.references.row.multiple{dim,ivar};
 
@@ -108,6 +132,10 @@ methods (Test, ParameterCombination="pairwise", TestTags="matrix")
         value1 = test_case.values.matrix{2,dim};
         value2 = test_case.values.scalar{1,dim};
 
+        % reduce order of polynomials
+        value1 = project(value1,restrict_terms(sparsity(value1),0:4));
+        value2 = project(value2,restrict_terms(sparsity(value2),0:4));
+
         reference = test_case.references.matrix.single{dim,ivar};
 
         test_case.evaluate_subs_single(symb1,symb2,ivar,value1,value2,reference);
@@ -117,6 +145,10 @@ methods (Test, ParameterCombination="pairwise", TestTags="matrix")
         % Test substitution of multiple variables in a column vector.
         value1 = test_case.values.matrix{1,dim};
         value2 = test_case.values.vector{1,value1.nvars+1};
+
+        % reduce order of polynomials
+        value1 = project(value1,restrict_terms(sparsity(value1),0:4));
+        value2 = project(value2,restrict_terms(sparsity(value2),0:4));
 
         reference = test_case.references.matrix.multiple{dim,ivar};
 

--- a/tests/references/eval_binary.m
+++ b/tests/references/eval_binary.m
@@ -44,6 +44,11 @@ switch (op)
         arg2_double = 1+double(subs(arg2,vars,ones(size(vars))));
         res = rdivide(arg1,arg2_double);
 
+    case "power"
+        % binary power
+        degs = ceil(2*double(cleanpoly(arg2,[],0)));
+        res = power(arg1,degs);
+
     otherwise
         error('Not implemented: %s.', op)
 end

--- a/tests/references/eval_horzcat.m
+++ b/tests/references/eval_horzcat.m
@@ -1,0 +1,27 @@
+% SPDX-FileCopyrightText: 2026 Institute of Flight Mechanics and Controls, University of Stuttgart
+% SPDX-FileCopyrightText: Author(s): Torbjørn Cunis <tcunis@ifr.uni-stuttgart.de>
+% SPDX-FileContributor: For a full list of contributors, see <https://github.com/ifr-ofc/casos>
+%
+% SPDX-License-Identifier: GPL-3.0-only
+
+function res = eval_horzcat(arg1,arg2)
+% Evaluate horizontal concatenation.
+
+% detect empty polynomials
+if (isempty(arg1) && isempty(arg2))
+    res = polynomial(zeros(size(arg1,1)+size(arg2,1),0));
+    return
+
+elseif isempty(arg1)
+    res = arg2;
+    return
+
+elseif isempty(arg2)
+    res = arg1;
+    return
+end
+
+% else
+res = horzcat(arg1,arg2);
+
+end

--- a/tests/references/eval_horzcat.m
+++ b/tests/references/eval_horzcat.m
@@ -9,7 +9,16 @@ function res = eval_horzcat(arg1,arg2)
 
 % detect empty polynomials
 if (isempty(arg1) && isempty(arg2))
-    res = polynomial(zeros(size(arg1,1)+size(arg2,1),0));
+    if (size(arg1,1) == 0 && size(arg2,1) == 0)
+        sz = size(arg1) + size(arg2);
+    else
+        sz = [
+            max(size(arg1,1),size(arg2,1))
+            min(size(arg1,2),size(arg2,2))
+        ]';
+    end
+    
+    res = polynomial(zeros(sz));
     return
 
 elseif isempty(arg1)

--- a/tests/references/eval_poly2basis.m
+++ b/tests/references/eval_poly2basis.m
@@ -9,8 +9,8 @@ function res = eval_poly2basis(arg1,arg2)
 
 assert(isequal(size(arg1),size(arg2)), 'Size mismatch.')
 
-if isempty(arg1)
-    % handle empty polynomial
+if isempty(arg1) || isempty(arg2)
+    % handle empty polynomial or basis
     res = zeros(0,1);
     return
 end

--- a/tests/references/eval_repmat.m
+++ b/tests/references/eval_repmat.m
@@ -7,6 +7,12 @@
 function res = eval_repmat(arg,m,n)
 % Evaluate repmat operation.
 
+if (nargin < 3)
+    % single dimension or size array given
+    n = m(end);
+    m = m(1);
+end
+
 if (m == 0 || n == 0)
     % return empty polynomial
     res = polynomial(zeros(size(arg).*[m n]));

--- a/tests/references/eval_vertcat.m
+++ b/tests/references/eval_vertcat.m
@@ -1,0 +1,27 @@
+% SPDX-FileCopyrightText: 2026 Institute of Flight Mechanics and Controls, University of Stuttgart
+% SPDX-FileCopyrightText: Author(s): Torbjørn Cunis <tcunis@ifr.uni-stuttgart.de>
+% SPDX-FileContributor: For a full list of contributors, see <https://github.com/ifr-ofc/casos>
+%
+% SPDX-License-Identifier: GPL-3.0-only
+
+function res = eval_vertcat(arg1,arg2)
+% Evaluate vertical concatenation.
+
+% detect empty polynomials
+if (isempty(arg1) && isempty(arg2))
+    res = polynomial(zeros(0,size(arg1,2)+size(arg2,2)));
+    return
+
+elseif isempty(arg1)
+    res = arg2;
+    return
+
+elseif isempty(arg2)
+    res = arg1;
+    return
+end
+
+% else
+res = vertcat(arg1,arg2);
+
+end

--- a/tests/references/eval_vertcat.m
+++ b/tests/references/eval_vertcat.m
@@ -9,7 +9,16 @@ function res = eval_vertcat(arg1,arg2)
 
 % detect empty polynomials
 if (isempty(arg1) && isempty(arg2))
-    res = polynomial(zeros(0,size(arg1,2)+size(arg2,2)));
+    if (size(arg1,2) == 0 && size(arg2,2) == 0)
+        sz = size(arg1) + size(arg2);
+    else
+        sz = [
+            min(size(arg1,1),size(arg2,1))
+            max(size(arg1,2),size(arg2,2))
+        ]';
+    end
+    
+    res = polynomial(zeros(sz));
     return
 
 elseif isempty(arg1)

--- a/tests/references/generateRandomSparsity.m
+++ b/tests/references/generateRandomSparsity.m
@@ -4,7 +4,7 @@
 %
 % SPDX-License-Identifier: GPL-3.0-only
 
-function sp = generateRandomSparsity(sz,variables,degmax)
+function sp = generateRandomSparsity(sz,variables,degmax,density,monomial)
 % Generate a random sparsity pattern.
 
 select_variables = (randn(length(variables),1) > 0);
@@ -15,30 +15,50 @@ x = variables(select_variables);
 % number of variables
 n = length(x);
 
-% create indices (0-index)
+% create subindices (0-index)
 I = 0:sz(1)-1;
 J = 0:sz(2)-1;
 
-% create degree vector
-D = cell(1,n);
-D(:) = {0:degmax};
+% permute subindices
+[I,J] = ndgrid(I,J);
 
-% permute indices and degrees
-[I,J,D{:}] = ndgrid(I,J,D{:});
+% create linear indices
+idx = 1:numel(I);
 
-% select random indices and degrees
-select_entries = (randn(numel(I),1) > 0);
+if (nargin > 3 && density < 1)
+    % generate matrix sparsity
+    idx(rand(size(idx)) > density) = 0;
+end
 
-i = squeeze(I(select_entries));
-j = squeeze(J(select_entries));
+if (nargin > 4 && monomial)
+    % create matrix of monomials
+    D = arrayfun(@(~) randi(degmax,[length(idx) 1]), 1:n, 'UniformOutput', false);
+    % select all nonzero indices
+    select_entries = (idx(:) ~= 0);
+
+else
+    % create degree vector
+    D = cell(1,n);
+    D(:) = {0:degmax};
+    
+    % permute linear indices and degrees
+    [idx,D{:}] = ndgrid(idx,D{:});
+    
+    % select random indices and degrees
+    select_entries = (idx(:) ~= 0 & randn(numel(idx),1) > 0);
+end
+
+idx = squeeze(idx(select_entries));
+i = squeeze(I(idx));
+j = squeeze(J(idx));
 degree_vectors = cellfun(@(d) squeeze(d(select_entries)), D, 'UniformOutput', false);
 
 if isempty(degree_vectors)
     % empty degrees
-    degrees = zeros(length(i),0);
+    degrees = zeros(length(i),length(x));
 else
     % concatenate
-    degrees = [degree_vectors{:}];
+    degrees = reshape([degree_vectors{:}],length(i),length(x));
 end
 
 % create sparsity pattern

--- a/tests/references/generateReferences.m
+++ b/tests/references/generateReferences.m
@@ -250,7 +250,7 @@ for op = ["mtimes" "kron"]
             arg1 = reference_values.vector{1,d1}';
             arg2 = reference_values.vector{2,d2};
 
-            if ~isequal(op,"kron") && (size(arg1,2) ~= size(arg2,1))
+            if ~isequal(op,"kron") && (~isscalar(arg1) && ~isscalar(arg2) && size(arg1,2) ~= size(arg2,1))
                 % dimension mismatch
                 continue
             end
@@ -277,7 +277,7 @@ for op = ["mtimes" "kron"]
             arg1 = reference_values.matrix{1,d1};
             arg2 = reference_values.matrix{3,d2};
 
-            if ~isequal(op,"kron") && (size(arg1,2) ~= size(arg2,1))
+            if ~isequal(op,"kron") && (~isscalar(arg1) && ~isscalar(arg2) && size(arg1,2) ~= size(arg2,1))
                 % dimension mismatch
                 continue
             end

--- a/tests/references/generateReferences.m
+++ b/tests/references/generateReferences.m
@@ -315,7 +315,7 @@ for k1 = 1:noPoly
     arg1 = reference_values.scalar{1,k1};
 
     vars = arg1.varname;
-    reference_value_double = double(subs(arg1,vars,ones(size(vars))));
+    reference_value_double = 1+double(subs(arg1,vars,ones(size(vars))));
 
     for k2 = 1:noPoly
         arg2 = reference_values.scalar{2,k2};
@@ -329,7 +329,7 @@ for k2 = 1:noPoly
     arg2 = reference_values.scalar{2,k2};
 
     vars = arg2.varname;
-    reference_value_double = double(subs(arg2,vars,ones(size(vars))));
+    reference_value_double = 1+double(subs(arg2,vars,ones(size(vars))));
 
     for k1 = 1:noPoly
         arg1 = reference_values.scalar{1,k1};

--- a/tests/references/generateReferences.m
+++ b/tests/references/generateReferences.m
@@ -497,7 +497,11 @@ for d1 = 1:maxdim
         arg1 = reference_values.vector{1,d1};
         arg2 = reference_values.vector{2,d2};
 
-        if ~isequal(size(arg1),size(arg2))
+        if isscalar(arg1)
+            % repeat scalar argument
+            arg1 = eval_repmat(arg1,size(arg2));
+
+        elseif ~isequal(size(arg1),size(arg2))
             % size mismatch
             continue;
         end
@@ -513,7 +517,11 @@ for d1 = 1:maxdim
         arg1 = reference_values.vector{1,d1}';
         arg2 = reference_values.vector{2,d2}';
 
-        if ~isequal(size(arg1),size(arg2))
+        if isscalar(arg1)
+            % repeat scalar argument
+            arg1 = eval_repmat(arg1,size(arg2));
+
+        elseif ~isequal(size(arg1),size(arg2))
             % size mismatch
             continue;
         end
@@ -529,7 +537,11 @@ for d1 = 1:maxdim
         arg1 = reference_values.matrix{1,d1};
         arg2 = reference_values.matrix{2,d2};
 
-        if ~isequal(size(arg1),size(arg2))
+        if isscalar(arg1)
+            % repeat scalar argument
+            arg1 = eval_repmat(arg1,size(arg2));
+
+        elseif ~isequal(size(arg1),size(arg2))
             % size mismatch
             continue;
         end

--- a/tests/references/generateReferences.m
+++ b/tests/references/generateReferences.m
@@ -725,6 +725,10 @@ for ivar = 1:4
         arg = reference_values.scalar{1,k};
         new = reference_values.scalar{2,k};
 
+        % reduce order of polynomials
+        arg = cleanpoly(arg,[],0:4);
+        new = cleanpoly(new,[],0:4);
+
         reference_subs.scalar.single{k,ivar} = multipoly2struct(eval_subs("single",arg,ivar,new));
     end
 
@@ -732,6 +736,10 @@ for ivar = 1:4
     for d = 1:maxdim
         arg = reference_values.vector{1,d};
         new = reference_values.scalar{1,d};
+
+        % reduce order of polynomials
+        arg = cleanpoly(arg,[],0:4);
+        new = cleanpoly(new,[],0:4);
 
         reference_subs.column.single{d,ivar} = multipoly2struct(eval_subs("single",arg,ivar,new));
     end
@@ -741,6 +749,10 @@ for ivar = 1:4
         arg = reference_values.vector{2,d}';
         new = reference_values.scalar{2,d};
 
+        % reduce order of polynomials
+        arg = cleanpoly(arg,[],0:4);
+        new = cleanpoly(new,[],0:4);
+
         reference_subs.row.single{d,ivar} = multipoly2struct(eval_subs("single",arg,ivar,new));
     end
 
@@ -748,6 +760,10 @@ for ivar = 1:4
     for d = 1:maxdim
         arg = reference_values.matrix{2,d};
         new = reference_values.scalar{1,d};
+
+        % reduce order of polynomials
+        arg = cleanpoly(arg,[],0:4);
+        new = cleanpoly(new,[],0:4);
 
         reference_subs.matrix.single{d,ivar} = multipoly2struct(eval_subs("single",arg,ivar,new));
     end
@@ -765,6 +781,10 @@ for ivar = 1:4
         arg = reference_values.scalar{2,k};
         new = reference_values.vector{2,arg.nvars+1};
 
+        % reduce order of polynomials
+        arg = cleanpoly(arg,[],0:4);
+        new = cleanpoly(new,[],0:4);
+
         reference_subs.scalar.multiple{k,ivar} = multipoly2struct(eval_subs("multiple",arg,ivar,new));
     end
 
@@ -772,6 +792,10 @@ for ivar = 1:4
     for d = 1:maxdim
         arg = reference_values.vector{2,d};
         new = reference_values.vector{1,arg.nvars+1};
+
+        % reduce order of polynomials
+        arg = cleanpoly(arg,[],0:4);
+        new = cleanpoly(new,[],0:4);
 
         reference_subs.column.multiple{d,ivar} = multipoly2struct(eval_subs("multiple",arg,ivar,new));
     end
@@ -781,6 +805,10 @@ for ivar = 1:4
         arg = reference_values.vector{1,d}';
         new = reference_values.vector{2,arg.nvars+1};
 
+        % reduce order of polynomials
+        arg = cleanpoly(arg,[],0:4);
+        new = cleanpoly(new,[],0:4);
+
         reference_subs.row.multiple{d,ivar} = multipoly2struct(eval_subs("multiple",arg,ivar,new));
     end
 
@@ -788,6 +816,10 @@ for ivar = 1:4
     for d = 1:maxdim
         arg = reference_values.matrix{1,d};
         new = reference_values.vector{1,arg.nvars+1};
+
+        % reduce order of polynomials
+        arg = cleanpoly(arg,[],0:4);
+        new = cleanpoly(new,[],0:4);
 
         reference_subs.matrix.multiple{d,ivar} = multipoly2struct(eval_subs("multiple",arg,ivar,new));
     end

--- a/tests/references/generateReferences.m
+++ b/tests/references/generateReferences.m
@@ -20,6 +20,7 @@ variables = casos.Indeterminates('x',5);
 noPoly = 10;
 maxdim = 6;
 maxdeg = 3;
+density = 0.7;
 
 % generate scalar values
 test_values_struct.scalar = cell(2,noPoly);
@@ -28,7 +29,7 @@ reference_values.scalar = cell(2,noPoly);
 for k = 1:numel(test_values_struct.scalar)
     % create scalars
     [test_values_struct.scalar(k),reference_values.scalar(k)] = ...
-                        generateTestPolynomials([1 1],variables,maxdeg);
+                        generateTestPolynomials([1 1],variables,maxdeg,density);
 end
 
 % generate (column) vector values
@@ -38,24 +39,27 @@ reference_values.vector = cell(2,maxdim);
 for dim = 1:maxdim
     % create vectors of same dimensions
     [test_values_struct.vector(1,dim),reference_values.vector(1,dim)] = ...
-                    generateTestPolynomials([dim-1 1],variables,maxdeg);
+                    generateTestPolynomials([dim-1 1],variables,maxdeg,density);
     [test_values_struct.vector(2,dim),reference_values.vector(2,dim)] = ...
-                    generateTestPolynomials([dim-1 1],variables,maxdeg);
+                    generateTestPolynomials([dim-1 1],variables,maxdeg,density);
 end
 
 % generate matrix values
-test_values_struct.matrix = cell(3,maxdim);
-reference_values.matrix = cell(3,maxdim);
+test_values_struct.matrix = cell(4,maxdim);
+reference_values.matrix = cell(4,maxdim);
 
 for dim = 1:maxdim
     % generate matrices of same dimensions
     [test_values_struct.matrix(1,dim),reference_values.matrix(1,dim)] = ...
-        generateTestPolynomials([dim-1 maxdim-dim],variables,maxdeg);
+        generateTestPolynomials([dim-1 maxdim-dim],variables,maxdeg,density);
     [test_values_struct.matrix(2,dim),reference_values.matrix(2,dim)] = ...
-        generateTestPolynomials([dim-1 maxdim-dim],variables,maxdeg);
+        generateTestPolynomials([dim-1 maxdim-dim],variables,maxdeg,density);
     % generate matrices of different dimensions
     [test_values_struct.matrix(3,dim),reference_values.matrix(3,dim)] = ...
-        generateTestPolynomials([dim maxdim-dim],variables,maxdeg);
+        generateTestPolynomials([dim maxdim-dim],variables,maxdeg,density);
+    % generate matrices of monomials
+    [test_values_struct.matrix(4,dim),reference_values.matrix(4,dim)] = ...
+        generateTestPolynomials([dim-1 maxdim-dim],variables,maxdeg,density,true);
 end
 
 save("reference_values.mat","test_values_struct");
@@ -115,7 +119,8 @@ disp("========================================")
 reference_binary = struct('scalar',struct, ...
                              'inner',struct, ...
                              'outer',struct, ...
-                             'matrix',struct ...
+                             'matrix',struct, ...
+                             'monomials',struct ...
 );
 
 % element-wise addition, subtraction, and multiplication
@@ -169,6 +174,23 @@ for op = ["plus" "minus" "times" "ldivide" "rdivide" "power"]
             reference_binary.matrix.(op){d1,d2} = multipoly2struct(eval_binary(op,arg1,arg2));
         end
     end    
+
+    % on matrix of monomials
+    reference_binary.monomials.(op) = cell(maxdim,maxdim);
+    for d1 = 1:maxdim
+        for d2 = 1:maxdim
+            arg1 = reference_values.matrix{4,d1};
+            arg2 = reference_values.matrix{2,d2};
+
+            if (~isrow(arg1) && ~isrow(arg2) && size(arg1,1) ~= size(arg2,1)) ...
+                    || (~iscolumn(arg1) && ~iscolumn(arg2) && size(arg1,2) ~= size(arg2,2))
+                % dimension mismatch
+                continue
+            end
+
+            reference_binary.monomials.(op){d1,d2} = multipoly2struct(eval_binary(op,arg1,arg2));
+        end
+    end 
 end
 
 save("reference_values.mat","reference_binary","-append")

--- a/tests/references/generateReferences.m
+++ b/tests/references/generateReferences.m
@@ -802,11 +802,11 @@ for d1 = 1:maxdim
         reference_concat.column.diagcat{d1,d2} = multipoly2struct(blkdiag(arg1,arg2));
         % horizontal concatenation
         if isempty(arg1) || isempty(arg2) || size(arg1,1) == size(arg2,1)
-            reference_concat.column.horzcat{d1,d2} = multipoly2struct(horzcat(arg1,arg2));
+            reference_concat.column.horzcat{d1,d2} = multipoly2struct(eval_horzcat(arg1,arg2));
         end
         % vertical concatenation 
         if isempty(arg1) || isempty(arg2) || size(arg1,2) == size(arg2,2)
-            reference_concat.column.vertcat{d1,d2} = multipoly2struct(vertcat(arg1,arg2));
+            reference_concat.column.vertcat{d1,d2} = multipoly2struct(eval_vertcat(arg1,arg2));
         end
     end
 end
@@ -825,11 +825,11 @@ for d1 = 1:maxdim
         reference_concat.row.diagcat{d1,d2} = multipoly2struct(blkdiag(arg1,arg2));
         % horizontal concatenation
         if isempty(arg1) || isempty(arg2) || size(arg1,1) == size(arg2,1)
-            reference_concat.row.horzcat{d1,d2} = multipoly2struct(horzcat(arg1,arg2));
+            reference_concat.row.horzcat{d1,d2} = multipoly2struct(eval_horzcat(arg1,arg2));
         end
         % vertical concatenation 
         if isempty(arg1) || isempty(arg2) || size(arg1,2) == size(arg2,2)
-            reference_concat.row.vertcat{d1,d2} = multipoly2struct(vertcat(arg1,arg2));
+            reference_concat.row.vertcat{d1,d2} = multipoly2struct(eval_vertcat(arg1,arg2));
         end
     end
 end
@@ -846,19 +846,13 @@ for d1 = 1:maxdim
 
         % diagonal concatenation
         reference_concat.matrix.diagcat{d1,d2} = multipoly2struct(blkdiag(arg1,arg2));
-        if isempty(arg1) && isempty(arg2)
-            % empty concatenation
-            reference_concat.matrix.horzcat{d1,d2} = multipoly2struct(polynomial);
-            reference_concat.matrix.vertcat{d1,d2} = multipoly2struct(polynomial);
-            continue
-        end
         % horizontal concatenation
         if isempty(arg1) || isempty(arg2) || size(arg1,1) == size(arg2,1)
-            reference_concat.matrix.horzcat{d1,d2} = multipoly2struct(horzcat(arg1,arg2));
+            reference_concat.matrix.horzcat{d1,d2} = multipoly2struct(eval_horzcat(arg1,arg2));
         end
         % vertical concatenation 
         if isempty(arg1) || isempty(arg2) || size(arg1,2) == size(arg2,2)
-            reference_concat.matrix.vertcat{d1,d2} = multipoly2struct(vertcat(arg1,arg2));
+            reference_concat.matrix.vertcat{d1,d2} = multipoly2struct(eval_vertcat(arg1,arg2));
         end
     end
 end

--- a/tests/references/generateReferences.m
+++ b/tests/references/generateReferences.m
@@ -120,7 +120,7 @@ reference_binary = struct('scalar',struct, ...
 
 % element-wise addition, subtraction, and multiplication
 % as well as left-side (B.\A) and right-side (A./B) division
-for op = ["plus" "minus" "times" "ldivide" "rdivide"]
+for op = ["plus" "minus" "times" "ldivide" "rdivide" "power"]
     % on scalar values
     reference_binary.scalar.(op) = cell(noPoly,noPoly);
     for k1 = 1:noPoly

--- a/tests/references/generateTestPolynomials.m
+++ b/tests/references/generateTestPolynomials.m
@@ -4,10 +4,10 @@
 %
 % SPDX-License-Identifier: GPL-3.0-only
 
-function [test_value,reference_value] = generateTestPolynomials(sz,variables,degmax)
+function [test_value,reference_value] = generateTestPolynomials(sz,variables,degmax,varargin)
 % Generate test polynomials from CaΣoS and Multipoly
 
-sp1 = generateRandomSparsity(sz,variables,degmax);
+sp1 = generateRandomSparsity(sz,variables,degmax,varargin{:});
 
 % generate random coefficients
 coeffs1 = rand(1,sp1.nnz);

--- a/tests/references/multipoly2struct.m
+++ b/tests/references/multipoly2struct.m
@@ -18,8 +18,8 @@ if isempty(poly)
     return
 
 else
-    % ensure polynomial
-    poly = polynomial(poly);
+    % ensure polynomial without zero terms
+    poly = polynomial(poly + 0);
 end
 
 coeffs = poly.coefficient;


### PR DESCRIPTION
This PR fixes various errors in the polynomial arithmetics that were revealed by unit tests.

Notable changes:

- Exception `IncompatibleSizesError` is thrown for all dimension mismatches.
- Element-wise `power` is re-implemented to avoid dependency on [CasADi's implementation](https://github.com/iFR-OFC/casos/issues/108) in v3.6.*
- The `spy` method for sparsity indicates entries with order of 10 or larger by `x` to avoid character overflow.

Changes to unit tests:

- Unit tests expect `IncompatibleSizesError` exception for dimension mismatches.
- Tests of substitution limits order of polynomials to reduce computation time.
- Projection (as well as `poly2basis`) uses a dense basis.
- New tests for element-wise power as binary operation.
- Sparse reference values for all operations.

Reference values can be found [here](https://github.com/iFR-OFC/casos/releases/download/v1.0.1-pre.3/reference_values.mat).