### PR TITLE
Build tools and meta data

### DIFF
--- a/+casos/@CasosMeta/CasosMeta.m
+++ b/+casos/@CasosMeta/CasosMeta.m
@@ -1,0 +1,19 @@
+classdef (Sealed) CasosMeta
+% Meta information for CaΣoS.
+%
+% - version: Returns version in the format 'x.y.z(+)'.
+% - git_revision: Returns git revision ID.
+%
+
+methods
+    function obj = CasosMeta()
+        error('Forbidden.')
+    end
+end
+
+methods (Static)
+    v = version;
+    v = git_revision;
+end
+
+end

--- a/+casos/@CasosMeta/CasosMeta.m
+++ b/+casos/@CasosMeta/CasosMeta.m
@@ -1,3 +1,9 @@
+% SPDX-FileCopyrightText: 2026 Institute of Flight Mechanics and Controls, University of Stuttgart
+% SPDX-FileCopyrightText: Author(s): Torbjørn Cunis <tcunis@ifr.uni-stuttgart.de>
+% SPDX-FileContributor: For a full list of contributors, see <https://github.com/ifr-ofc/casos>
+%
+% SPDX-License-Identifier: GPL-3.0-only
+
 classdef (Sealed) CasosMeta
 % Meta information for CaΣoS.
 %

--- a/+casos/@CasosMeta/version.m
+++ b/+casos/@CasosMeta/version.m
@@ -1,1 +1,0 @@
-function v = version(), v = '1.0.0+'; end

--- a/+casos/@CasosMeta/version.m
+++ b/+casos/@CasosMeta/version.m
@@ -1,0 +1,1 @@
+function v = version(), v = '1.0.0+'; end

--- a/build/copyMfiles.m
+++ b/build/copyMfiles.m
@@ -1,3 +1,9 @@
+% SPDX-FileCopyrightText: 2026 Institute of Flight Mechanics and Controls, University of Stuttgart
+% SPDX-FileCopyrightText: Author(s): Torbjørn Cunis and Renato Loureiro <tcunis@ifr.uni-stuttgart.de>
+% SPDX-FileContributor: For a full list of contributors, see <https://github.com/ifr-ofc/casos>
+%
+% SPDX-License-Identifier: GPL-3.0-only
+
 function copyMfiles(source, destination)
 % Copy only m-files.
 

--- a/build/copyMfiles.m
+++ b/build/copyMfiles.m
@@ -1,0 +1,34 @@
+function copyMfiles(source, destination)
+% Copy only m-files.
+
+% get all .m files recursively
+files = dir(join([source "**" "*.m"], filesep));
+
+if ~isfolder(destination) 
+    % create destination folder 
+    mkdir(destination); 
+end
+
+for i = 1:length(files)
+    % copy each file 
+    file_path = fullfile(files(i).folder, files(i).name);
+    
+    % remove pwd from source path for relative comparison
+    relative_path = strrep(files(i).folder, join([pwd string(filesep)],""), "");
+    relative_path = strrep(relative_path, source, "");
+
+    if startsWith(relative_path, filesep)
+        % remove leading file separator
+        relative_path{1}(1) = '';
+    end
+    
+    folder_at_destination = fullfile(destination, relative_path);
+    if ~isfolder(folder_at_destination)
+        mkdir(folder_at_destination);
+    end
+
+    % dest = fullfile(folder_at_destination, files(i).name);
+    copyfile(file_path, folder_at_destination);
+end
+
+end

--- a/build/generate_metadata.m
+++ b/build/generate_metadata.m
@@ -1,3 +1,9 @@
+% SPDX-FileCopyrightText: 2026 Institute of Flight Mechanics and Controls, University of Stuttgart
+% SPDX-FileCopyrightText: Author(s): Torbjørn Cunis <tcunis@ifr.uni-stuttgart.de>
+% SPDX-FileContributor: For a full list of contributors, see <https://github.com/ifr-ofc/casos>
+%
+% SPDX-License-Identifier: GPL-3.0-only
+
 function generate_metadata(path_to_source, version)
 % Create CaΣoS meta data.
 

--- a/build/generate_metadata.m
+++ b/build/generate_metadata.m
@@ -1,0 +1,27 @@
+function generate_metadata(path_to_source, version)
+% Create CaΣoS meta data.
+
+path_to_meta = join([path_to_source "+casos" "@CasosMeta"], filesep);
+
+%% Create method to query version
+% create a method file
+lines_version = compose("function v = version(), v = '%s'; end", version);
+writelines(lines_version, join([path_to_meta "version.m"], filesep));
+
+%% Create methods to query git commit
+% only if inside a git repository
+try
+    % git repository
+    repo = gitrepo;
+    last_commit = repo.LastCommit;
+
+    % create method to query git revision
+    lines_revision = compose("function v = git_revision(), v = '%s'; end", last_commit.ID);
+    writelines(lines_revision, join([path_to_meta "git_revision.m"], filesep));
+
+catch
+    % nothing to do
+    warning("Not inside a git repository.")
+end
+
+end

--- a/build/generate_metadata.m
+++ b/build/generate_metadata.m
@@ -7,12 +7,15 @@
 function generate_metadata(path_to_source, version)
 % Create CaΣoS meta data.
 
+% REUSE-IgnoreStart
+license_header = "% SPDX-License-Identifier: CC0-1.0";
+% REUSE-IgnoreEnd
 path_to_meta = join([path_to_source "+casos" "@CasosMeta"], filesep);
 
 %% Create method to query version
 % create a method file
 lines_version = compose("function v = version(), v = '%s'; end", version);
-writelines(lines_version, join([path_to_meta "version.m"], filesep));
+writelines([license_header lines_version], join([path_to_meta "version.m"], filesep));
 
 %% Create methods to query git commit
 % only if inside a git repository
@@ -23,7 +26,7 @@ try
 
     % create method to query git revision
     lines_revision = compose("function v = git_revision(), v = '%s'; end", last_commit.ID);
-    writelines(lines_revision, join([path_to_meta "git_revision.m"], filesep));
+    writelines([license_header lines_revision], join([path_to_meta "git_revision.m"], filesep));
 
 catch
     % nothing to do

--- a/build/package_toolbox.m
+++ b/build/package_toolbox.m
@@ -1,0 +1,53 @@
+function package_toolbox(version)
+% Create a zip file.
+%
+% IMPORTANT: The script requires the current folder to be the casos root
+% folder!
+
+assert(isfolder("+casos"), "Current folder must be casos root folder.")
+
+% ensure string
+version = string(version);
+
+%% Create temporary folder structure
+% create the following folder structure:
+%
+%   casos/ temp/
+%   |-- +casos/
+%   |       :
+%   |-- doc/
+%   |       GettingStarted.mlx
+%   |-- demo/
+%   |       :
+
+if exist("temp","dir")
+    % clear temporary folder and structure
+    rmdir("temp","s")
+end
+
+mkdir("temp")
+mkdir("temp/+casos")
+% mkdir("temp/doc")
+mkdir("temp/demo")
+
+% copy source folder
+copyMfiles("+casos","temp/+casos")
+% copy examples from demo folder
+copyMfiles("demo","temp/demo")
+% copy Getting Started guide
+% copyfile("build/GettingStarted.mlx","temp/doc/")
+% copy license
+copyfile("LICENSES/GPL-3.0-only.txt","temp")
+
+%% Generate meta data
+% populate CasosMeta class folder
+generate_metadata("temp",version);
+
+%% Create zip file
+% use temporary folder as root
+zip(join(["build/casos" version "matlab.zip"],"-"), [
+    "+casos"
+    "demo"
+    % "doc"
+    "GPL-3.0-only.txt"
+], "temp")

--- a/build/package_toolbox.m
+++ b/build/package_toolbox.m
@@ -1,3 +1,9 @@
+% SPDX-FileCopyrightText: 2026 Institute of Flight Mechanics and Controls, University of Stuttgart
+% SPDX-FileCopyrightText: Author(s): Torbjørn Cunis <tcunis@ifr.uni-stuttgart.de>
+% SPDX-FileContributor: For a full list of contributors, see <https://github.com/ifr-ofc/casos>
+%
+% SPDX-License-Identifier: GPL-3.0-only
+
 function package_toolbox(version)
 % Create a zip file.
 %
@@ -51,3 +57,5 @@ zip(join(["build/casos" version "matlab.zip"],"-"), [
     % "doc"
     "GPL-3.0-only.txt"
 ], "temp")
+
+end

--- a/build/package_toolbox.m
+++ b/build/package_toolbox.m
@@ -21,9 +21,9 @@ version = string(version);
 %   casos/ temp/
 %   |-- +casos/
 %   |       :
-%   |-- doc/
-%   |       GettingStarted.mlx
 %   |-- demo/
+%   |       :
+%   |-- LICENSES/
 %   |       :
 
 if exist("temp","dir")
@@ -33,17 +33,15 @@ end
 
 mkdir("temp")
 mkdir("temp/+casos")
-% mkdir("temp/doc")
 mkdir("temp/demo")
+mkdir("temp/LICENSES")
 
 % copy source folder
 copyMfiles("+casos","temp/+casos")
 % copy examples from demo folder
 copyMfiles("demo","temp/demo")
-% copy Getting Started guide
-% copyfile("build/GettingStarted.mlx","temp/doc/")
 % copy license
-copyfile("LICENSES/GPL-3.0-only.txt","temp")
+copyfile("LICENSES","temp/LICENSES")
 
 %% Generate meta data
 % populate CasosMeta class folder
@@ -54,8 +52,7 @@ generate_metadata("temp",version);
 zip(join(["build/casos" version "matlab.zip"],"-"), [
     "+casos"
     "demo"
-    % "doc"
-    "GPL-3.0-only.txt"
+    "LICENSES"
 ], "temp")
 
 end


### PR DESCRIPTION
This PR adds build tools and a singleton class `CasosMeta` for meta data, to be populated during the build process.

The meta data class cannot be instantiated and provides static methods to query information. At this point, we provide the current version of CaΣoS and the git revision (commit ID) from which CaΣoS was built, if available.

The build tools provide a function `package_toolbox` which performs the following tasks:

1. Copy all MATLAB files from the main folder (`+casos`) and the demo folder, along with the license file, into a temporary directory;
2. Populate the meta data class methods (in the temporary copy);
3. Compress the temporary copy into a zip archive.

>[!WARNING]
> Meta data is only available after the build process and in the released version. Calling the class methods from the source will fail!