### PR TITLE
Added new to_function_vec to generate cased function as vector inputs.

### DIFF
--- a/+casos/+package/+core/GenericPolynomial.m
+++ b/+casos/+package/+core/GenericPolynomial.m
@@ -178,6 +178,57 @@ methods
         f = to_sxfunction(obj,varargin{:});
     end
 
+    % new functions, to ensure backward compatibility
+    function f = to_function_vec(obj,varargin)
+        % Return casadi.Function object.
+        % Overload for default behaviour.
+        f = to_sxfunction_vec(obj,varargin{:});
+    end
+
+
+    function f = to_sxfunction_vec(obj,varargin)
+        % Return casadi.Function object using SX.
+        X = casadi.SX.sym('x',obj.nvars,1);
+        p = subs(obj,indeterminates(obj),casos.package.polynomial(X));
+       
+        % get casadi SX expression
+        p = casadi.substitute(casadi.SX(p), X, X);
+
+        % extract the indeterminate strings
+        indet_str = str(obj.indeterminates);
+
+        % normalize to string array
+        s = string(indet_str(:));
+
+        % remove trailing underscore+digits (e.g. "y_1" -> "y");
+        basesOnly = regexprep(s, '(_\d+)$', '');
+
+        % get unique names and counts
+        [bases, ~, ic] = unique(basesOnly, 'stable');
+        counts = accumarray(ic, 1);
+        
+        % for each indeterminate generate a) a string for vecotr b) and
+        % input variable
+        % create one SX symbol per base (column vectors) and keep names
+        vars = cell(numel(bases),1);
+        inputNames = cell(numel(bases),1);
+        for i = 1:numel(bases)
+            % casadi requires char names
+            nameChar = char(bases(i));
+            % create a column vector of length counts(i)
+            vars{i} = casadi.SX.sym(nameChar, counts(i), 1);
+            inputNames{i} = nameChar;
+        end
+
+        % concatenate all base vectors into one stacked vector X
+        inputs = vertcat(vars{:});
+        
+        p = casadi.substitute(p, X, inputs);
+
+        % create function with the base-named inputs
+        f = casadi.Function('f', vars, {p}, inputNames, {'poly'});
+    end
+
     %% Concatenation
     function p = cat(dim,varargin)
         % Generic concatenation.


### PR DESCRIPTION
Added a first version on how to generate functions with (several) vector inputs. New interface, to keep old `to_function` for legacy/backward compatibility.

Simple test in MATLAB

```
x = casos.Indeterminates('x',3);
u = casos.Indeterminates('u',3);
w = casos.Indeterminates('w',3);


p = [-3*x(1)^2 + x(2)^2  + x(3)^2 + u'*u + w'*w- 1;
    -x(1)^2 + x(2)^2  + 6.7*x(3)^2 + u'*u + w'*w- 0.34;
    2*x(1)^2 + 3*x(2)^2  + 0.32*x(3)^2 + u'*u + w'*w- 12.45];


% new interface
pfun_new = to_function_vec(p)

% old interface
pfun_old = to_function(p)


% simple evaluation
randNum = rand(3,3);

xval = randNum(:,1);
uval = randNum(:,2);
wval = randNum(:,3);


pfun_new_val = pfun_new(uval,wval,xval)


X = num2cell([uval;wval;xval]);
pfun_old_val = pfun_old(X{:})
```

This test yields

```
pfun_new = 

f:(u[3],w[3],x[3])->(poly[3]) SXFunction

pfun_old = 

f:(u_1,u_2,u_3,w_1,w_2,w_3,x_1,x_2,x_3)->(poly[3]) SXFunction

pfun_new_val = 

[-1.24831, 1.65851, -10.0016]

pfun_old_val = 

[-1.24831, 1.65851, -10.0016]
```
